### PR TITLE
Extended Precision Mode (up to 30 decimal precision places; provided by Boost Multiprecision's float128)

### DIFF
--- a/src/acl_agemarkercore.cpp
+++ b/src/acl_agemarkercore.cpp
@@ -39,10 +39,10 @@ void AgemarkerCore::startCalculation()
     threadsShared.random = new MTRandom();
     threadsShared.runningThreads = new int();
     *threadsShared.runningThreads = this->runningThreads;
-    threadsShared.atomsUsed = new Data::Types::AtomicUInt64[ELEMENTS_COUNT];
+    threadsShared.atomsUsed = new std::vector<Data::Types::AtomicUInt64>;
     for (int x = 0; x < ELEMENTS_COUNT; ++x)
     {
-        threadsShared.atomsUsed[x] = 0;
+        threadsShared.atomsUsed->push_back(Data::Types::AtomicUInt64(0));
     }
 
     Data::Structs::CalculationThreadInput threadInput;

--- a/src/acl_agemarkercore.cpp
+++ b/src/acl_agemarkercore.cpp
@@ -20,7 +20,7 @@ AgemarkerCore::AgemarkerCore(Data::CalculationInput input)
 {
     qRegisterMetaType<Data::Types::IpValuesMap>("Data::Types::IpValuesMap");
     qRegisterMetaType<Data::Types::StatisticalUInt64>("Data::Types::StatisticalUInt64");
-    qRegisterMetaType<Data::Types::StatisticalFloat128>("Data::Types::StatisticalFloat128");
+    qRegisterMetaType<Data::Types::StatisticalFloat>("Data::Types::StatisticalFloat");
     this->data = input;
     this->runningThreads = input.threadsNumber;
 }
@@ -114,7 +114,7 @@ void AgemarkerCore::collectThreadResult(Data::Types::IpValuesMap result)
         }
         else
         {
-            this->calculatedIp.insert(std::pair<float128, uint64_t> (iter->first, iter->second));
+            this->calculatedIp.insert(std::pair<Float, uint64_t> (iter->first, iter->second));
         }
     }
     this->runningThreads--;

--- a/src/acl_agemarkercore.cpp
+++ b/src/acl_agemarkercore.cpp
@@ -20,7 +20,7 @@ AgemarkerCore::AgemarkerCore(Data::CalculationInput input)
 {
     qRegisterMetaType<Data::Types::IpValuesMap>("Data::Types::IpValuesMap");
     qRegisterMetaType<Data::Types::StatisticalUInt64>("Data::Types::StatisticalUInt64");
-    qRegisterMetaType<Data::Types::StatisticalDouble>("Data::Types::StatisticalDouble");
+    qRegisterMetaType<Data::Types::StatisticalFloat128>("Data::Types::StatisticalFloat128");
     this->data = input;
     this->runningThreads = input.threadsNumber;
 }
@@ -114,7 +114,7 @@ void AgemarkerCore::collectThreadResult(Data::Types::IpValuesMap result)
         }
         else
         {
-            this->calculatedIp.insert(std::pair<double, uint64_t> (iter->first, iter->second));
+            this->calculatedIp.insert(std::pair<float128, uint64_t> (iter->first, iter->second));
         }
     }
     this->runningThreads--;

--- a/src/acl_atoms.cpp
+++ b/src/acl_atoms.cpp
@@ -203,7 +203,7 @@ Data::Structs::CalculationAtomData Atoms::getAtomData()
         }
 
         Float atom = FMath::round(nor * this->data.multiplier);
-        this->atoms.all.push_back(FMath::boost_numeric_cast<uint64_t>(atom));
+        this->atoms.all.push_back(boost::numeric_cast<uint64_t>(atom));
 
         this->atoms.allSum += atoms.all[x];
         this->atoms.allEight.push_back(atoms.all[x] * 8);

--- a/src/acl_atoms.cpp
+++ b/src/acl_atoms.cpp
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2013 Mikhail Labushev.
+ *
+ * This file is a part of agemarker-core
+ * library distributed under the MIT License.
+ * For full terms see LICENSE file.
+ */
+
 #include "acl_atoms.h"
 
 using namespace ACL;
@@ -16,7 +24,7 @@ Atoms::~Atoms()
 
 Data::Structs::CalculationAtomData Atoms::getAtomData()
 {
-    double oxidesWeightSum[OXIDES_COUNT];
+    float128 oxidesWeightSum[OXIDES_COUNT];
     oxidesWeightSum[0] = ((this->data.elementsWeight[13] * 1) + (this->data.elementsWeight[7] * 2));
     oxidesWeightSum[1] = ((this->data.elementsWeight[21] * 1) + (this->data.elementsWeight[7] * 2));
     oxidesWeightSum[2] = ((this->data.elementsWeight[12] * 2) + (this->data.elementsWeight[7] * 3));
@@ -70,7 +78,7 @@ Data::Structs::CalculationAtomData Atoms::getAtomData()
     oxidesWeightSum[50] = ((this->data.elementsWeight[43] * 1) + (this->data.elementsWeight[7] * 2));
     oxidesWeightSum[51] = ((this->data.elementsWeight[54] * 2) + (this->data.elementsWeight[7] * 1));
     oxidesWeightSum[52] = ((this->data.elementsWeight[36] * 2) + (this->data.elementsWeight[7] * 1));
-    double oxidesPureElement[OXIDES_COUNT];
+    float128 oxidesPureElement[OXIDES_COUNT];
     oxidesPureElement[0] = ((this->data.elementsWeight[13] * 1) * (this->data.oxidesContent[0]) / (oxidesWeightSum[0]));
     oxidesPureElement[1] = ((this->data.elementsWeight[21] * 1) * (this->data.oxidesContent[1]) / (oxidesWeightSum[1]));
     oxidesPureElement[2] = ((this->data.elementsWeight[12] * 2) * (this->data.oxidesContent[2]) / (oxidesWeightSum[2]));
@@ -179,12 +187,12 @@ Data::Structs::CalculationAtomData Atoms::getAtomData()
     this->atoms.elementsNewContent[36] += oxidesPureElement[52];
     for (int x = 0; x < OXIDES_COUNT; ++x)
     {
-        double oxideOxygen = ((this->data.oxidesContent[x]) - (oxidesPureElement[x]));
+        float128 oxideOxygen = ((this->data.oxidesContent[x]) - (oxidesPureElement[x]));
         this->atoms.elementsNewContent[7] += oxideOxygen;
     }
     for (int x = 0; x < ELEMENTS_COUNT; ++x)
     {
-        double nor;
+        float128 nor;
         if (this->data.elementsContentUnits == Data::ElementsContentUnits::MassPercent)
         {
             nor = (this->atoms.elementsNewContent[x] / this->data.elementsWeight[x]);
@@ -193,7 +201,10 @@ Data::Structs::CalculationAtomData Atoms::getAtomData()
         {
             nor = this->atoms.elementsNewContent[x];
         }
-        this->atoms.all.push_back(nor * this->data.multiplier);
+
+        float128 atom = boost::multiprecision::round(nor * this->data.multiplier);
+        this->atoms.all.push_back(boost::numeric_cast<uint64_t>(atom));
+
         this->atoms.allSum += atoms.all[x];
         this->atoms.allEight.push_back(atoms.all[x] * 8);
         this->atoms.allEightSum += this->atoms.allEight[x];

--- a/src/acl_atoms.cpp
+++ b/src/acl_atoms.cpp
@@ -24,7 +24,7 @@ Atoms::~Atoms()
 
 Data::Structs::CalculationAtomData Atoms::getAtomData()
 {
-    float128 oxidesWeightSum[OXIDES_COUNT];
+    Float oxidesWeightSum[OXIDES_COUNT];
     oxidesWeightSum[0] = ((this->data.elementsWeight[13] * 1) + (this->data.elementsWeight[7] * 2));
     oxidesWeightSum[1] = ((this->data.elementsWeight[21] * 1) + (this->data.elementsWeight[7] * 2));
     oxidesWeightSum[2] = ((this->data.elementsWeight[12] * 2) + (this->data.elementsWeight[7] * 3));
@@ -78,7 +78,7 @@ Data::Structs::CalculationAtomData Atoms::getAtomData()
     oxidesWeightSum[50] = ((this->data.elementsWeight[43] * 1) + (this->data.elementsWeight[7] * 2));
     oxidesWeightSum[51] = ((this->data.elementsWeight[54] * 2) + (this->data.elementsWeight[7] * 1));
     oxidesWeightSum[52] = ((this->data.elementsWeight[36] * 2) + (this->data.elementsWeight[7] * 1));
-    float128 oxidesPureElement[OXIDES_COUNT];
+    Float oxidesPureElement[OXIDES_COUNT];
     oxidesPureElement[0] = ((this->data.elementsWeight[13] * 1) * (this->data.oxidesContent[0]) / (oxidesWeightSum[0]));
     oxidesPureElement[1] = ((this->data.elementsWeight[21] * 1) * (this->data.oxidesContent[1]) / (oxidesWeightSum[1]));
     oxidesPureElement[2] = ((this->data.elementsWeight[12] * 2) * (this->data.oxidesContent[2]) / (oxidesWeightSum[2]));
@@ -187,12 +187,12 @@ Data::Structs::CalculationAtomData Atoms::getAtomData()
     this->atoms.elementsNewContent[36] += oxidesPureElement[52];
     for (int x = 0; x < OXIDES_COUNT; ++x)
     {
-        float128 oxideOxygen = ((this->data.oxidesContent[x]) - (oxidesPureElement[x]));
+        Float oxideOxygen = ((this->data.oxidesContent[x]) - (oxidesPureElement[x]));
         this->atoms.elementsNewContent[7] += oxideOxygen;
     }
     for (int x = 0; x < ELEMENTS_COUNT; ++x)
     {
-        float128 nor;
+        Float nor;
         if (this->data.elementsContentUnits == Data::ElementsContentUnits::MassPercent)
         {
             nor = (this->atoms.elementsNewContent[x] / this->data.elementsWeight[x]);
@@ -202,8 +202,8 @@ Data::Structs::CalculationAtomData Atoms::getAtomData()
             nor = this->atoms.elementsNewContent[x];
         }
 
-        float128 atom = boost::multiprecision::round(nor * this->data.multiplier);
-        this->atoms.all.push_back(boost::numeric_cast<uint64_t>(atom));
+        Float atom = FMath::round(nor * this->data.multiplier);
+        this->atoms.all.push_back(FMath::boost_numeric_cast<uint64_t>(atom));
 
         this->atoms.allSum += atoms.all[x];
         this->atoms.allEight.push_back(atoms.all[x] * 8);

--- a/src/acl_atoms.h
+++ b/src/acl_atoms.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2013 Mikhail Labushev.
+ *
+ * This file is a part of agemarker-core
+ * library distributed under the MIT License.
+ * For full terms see LICENSE file.
+ */
+
 #ifndef ATOMS_H
 #define ATOMS_H
 

--- a/src/acl_calculationthread.cpp
+++ b/src/acl_calculationthread.cpp
@@ -52,7 +52,7 @@ void CalculationThread::removeThread()
 
 void CalculationThread::run()
 {
-    std::vector<float128> input = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    std::vector<Float> input = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
     uint64_t atomicWeightSelector, atomicWeightIterator;
     Data::Types::IpValuesMap ipMap;
     for (uint64_t l = this->threadInput.startIteration;
@@ -99,15 +99,15 @@ void CalculationThread::run()
             input[8] += input[input_it];
         }
         std::random_shuffle(input.begin(), input.end());
-        float128 ip = Math::roundFloat128(Math::ip(input, this->threadInput.logarithm), this->threadInput.decimalPrecision);
-        std::map<float128, uint64_t>::iterator it = ipMap.find(ip);
+        Float ip = FMath::round(Math::ip(input, this->threadInput.logarithm), this->threadInput.decimalPrecision);
+        std::map<Float, uint64_t>::iterator it = ipMap.find(ip);
         if (it != ipMap.end())
         {
             it->second += 1;
         }
         else
         {
-            ipMap.insert(std::pair<float128, uint64_t>(ip, 1));
+            ipMap.insert(std::pair<Float, uint64_t>(ip, 1));
         }
     }
     emit threadCalculationFinished(ipMap);

--- a/src/acl_calculationthread.cpp
+++ b/src/acl_calculationthread.cpp
@@ -52,7 +52,7 @@ void CalculationThread::removeThread()
 
 void CalculationThread::run()
 {
-    std::vector<double> input = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    std::vector<float128> input = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
     uint64_t atomicWeightSelector, atomicWeightIterator;
     Data::Types::IpValuesMap ipMap;
     for (uint64_t l = this->threadInput.startIteration;
@@ -99,15 +99,15 @@ void CalculationThread::run()
             input[8] += input[input_it];
         }
         std::random_shuffle(input.begin(), input.end());
-        double ip = Math::roundDouble(Math::ip(input, this->threadInput.logarithm), this->threadInput.decimalPrecision);
-        std::map<double, uint64_t>::iterator it = ipMap.find(ip);
+        float128 ip = Math::roundFloat128(Math::ip(input, this->threadInput.logarithm), this->threadInput.decimalPrecision);
+        std::map<float128, uint64_t>::iterator it = ipMap.find(ip);
         if (it != ipMap.end())
         {
             it->second += 1;
         }
         else
         {
-            ipMap.insert(std::pair<double, uint64_t>(ip, 1));
+            ipMap.insert(std::pair<float128, uint64_t>(ip, 1));
         }
     }
     emit threadCalculationFinished(ipMap);

--- a/src/acl_calculationthread.cpp
+++ b/src/acl_calculationthread.cpp
@@ -6,9 +6,6 @@
  * For full terms see LICENSE file.
  */
 
-#include <iostream>
-#include <QDebug>
-
 #include "acl_calculationthread.h"
 #include "acl_math.h"
 

--- a/src/acl_calculationthread.cpp
+++ b/src/acl_calculationthread.cpp
@@ -101,9 +101,9 @@ void CalculationThread::run()
             }
             atomicWeightGrid[8] += atomicWeightGrid[grid_it];
         }
-        //std::shuffle(atomicWeightGrid.begin(), atomicWeightGrid.end(), this->threadData.random->mtwister_engine);
+        std::shuffle(atomicWeightGrid.begin(), atomicWeightGrid.end(), this->threadData.random->mtwister_engine);
         Float ip = FMath::round(Math::ip(atomicWeightGrid, this->threadInput.logarithm), this->threadInput.decimalPrecision);
-        std::map<Float,0 uint64_t>::iterator it = ipMap.find(ip);
+        std::map<Float, uint64_t>::iterator it = ipMap.find(ip);
         if (it != ipMap.end())
         {
             it->second += 1;

--- a/src/acl_calculationthread.cpp
+++ b/src/acl_calculationthread.cpp
@@ -6,6 +6,9 @@
  * For full terms see LICENSE file.
  */
 
+#include <iostream>
+#include <QDebug>
+
 #include "acl_calculationthread.h"
 #include "acl_math.h"
 
@@ -24,7 +27,7 @@ CalculationThread::~CalculationThread()
     if (*this->threadData.runningThreads == 0)
     {
         delete this->threadData.random;
-        delete[] this->threadData.atomsUsed;
+        delete this->threadData.atomsUsed;
         delete this->threadData.runningThreads;
     }
 }
@@ -52,7 +55,7 @@ void CalculationThread::removeThread()
 
 void CalculationThread::run()
 {
-    std::vector<Float> input = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    std::vector<Float> atomicWeightGrid = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
     uint64_t atomicWeightSelector, atomicWeightIterator;
     Data::Types::IpValuesMap ipMap;
     for (uint64_t l = this->threadInput.startIteration;
@@ -68,15 +71,15 @@ void CalculationThread::run()
             this->pauseCond.wait(&this->syncMutex);
         }
         this->syncMutex.unlock();
-        std::fill(input.begin(), input.end(), 0);
+        std::fill(atomicWeightGrid.begin(), atomicWeightGrid.end(), 0);
         /* The loop below randomly places 8 atomic weights
          * from 'atomAllEight' to 'input' vector and fills
          * the 9th value of this vector with the total sum
          * of atomic weights in it.
          */
-        for (int input_it = 0; input_it < 8; ++input_it)
+        for (int grid_it = 0; grid_it < 8; ++grid_it)
         {
-            while (input[input_it] == 0)
+            while (atomicWeightGrid[grid_it] == 0)
             {
                 atomicWeightSelector = this->threadData.random->getRandomULongLong(1, this->threadInput.atomAllEightSum);
                 atomicWeightIterator = 0;
@@ -86,21 +89,21 @@ void CalculationThread::run()
                     {
                         atomicWeightIterator += this->threadInput.atomAllEight[elements_it];
                         if (atomicWeightSelector <= atomicWeightIterator
-                            && this->threadData.atomsUsed[elements_it] <
+                            && this->threadData.atomsUsed->at(elements_it) <
                             this->threadInput.atomAllEight[elements_it])
                         {
-                            input[input_it] = this->threadInput.elementsWeight[elements_it];
-                            ++this->threadData.atomsUsed[elements_it];
+                            atomicWeightGrid[grid_it] = this->threadInput.elementsWeight[elements_it];
+                            ++this->threadData.atomsUsed->at(elements_it);
                             break;
                         }
                     }
                 }
             }
-            input[8] += input[input_it];
+            atomicWeightGrid[8] += atomicWeightGrid[grid_it];
         }
-        std::random_shuffle(input.begin(), input.end());
-        Float ip = FMath::round(Math::ip(input, this->threadInput.logarithm), this->threadInput.decimalPrecision);
-        std::map<Float, uint64_t>::iterator it = ipMap.find(ip);
+        //std::shuffle(atomicWeightGrid.begin(), atomicWeightGrid.end(), this->threadData.random->mtwister_engine);
+        Float ip = FMath::round(Math::ip(atomicWeightGrid, this->threadInput.logarithm), this->threadInput.decimalPrecision);
+        std::map<Float,0 uint64_t>::iterator it = ipMap.find(ip);
         if (it != ipMap.end())
         {
             it->second += 1;

--- a/src/acl_data.h
+++ b/src/acl_data.h
@@ -15,12 +15,16 @@
 /* The number of oxides used in Agemarker calculations */
 #define OXIDES_COUNT            53
 
+#include <boost/multiprecision/float128.hpp>
+
 #include <atomic>
 #include <vector>
 #include <map>
 
 #include "acl_mtrandom.h"
 #include "acl_global.h"
+
+using namespace boost::multiprecision;
 
 namespace ACL
 {
@@ -149,16 +153,16 @@ namespace ACL
                 }
             };
             typedef StatisticalValue<uint64_t> StatisticalUInt64;
-            typedef StatisticalValue<double> StatisticalDouble;
+            typedef StatisticalValue<float128> StatisticalFloat128;
 
-            typedef std::map<double, uint64_t> IpValuesMap;
+            typedef std::map<float128, uint64_t> IpValuesMap;
         }
         /* Data structs used _internally_ in Agemarker Core Library. */
         namespace Structs
         {
             struct CalculationAtomData
             {
-                std::vector<double> elementsNewContent;
+                std::vector<float128> elementsNewContent;
                 std::vector<uint64_t> allEight;
                 std::vector<uint64_t> all;
                 uint64_t allEightSum = 0;
@@ -166,7 +170,7 @@ namespace ACL
             };
             struct CalculationThreadInput
             {
-                std::vector<double> elementsWeight;
+                std::vector<float128> elementsWeight;
                 std::vector<uint64_t> atomAllEight;
                 Logarithm logarithm;
                 uint64_t atomAllEightSum;
@@ -193,9 +197,9 @@ namespace ACL
         }
         struct CalculationInput
         {
-            std::vector<double> oxidesContent;
-            std::vector<double> elementsContent;
-            std::vector<double> elementsWeight;
+            std::vector<float128> oxidesContent;
+            std::vector<float128> elementsContent;
+            std::vector<float128> elementsWeight;
             int decimalPrecision;
             uint64_t multiplier;
             int intervalsNumber;
@@ -207,33 +211,33 @@ namespace ACL
         {
             CalculationInput calculationInput;
             std::vector<uint64_t> atoms;
-            std::vector<double> ip;
-            std::vector<double> ipSqrt;
+            std::vector<float128> ip;
+            std::vector<float128> ipSqrt;
             std::vector<uint64_t> ipFrequency;
             std::vector<uint64_t> ipTheoreticalFrequency;
             uint64_t atomsSum;
-            Types::StatisticalDouble ipAverage;
-            Types::StatisticalDouble ipSqrtAverage;
-            Types::StatisticalDouble ipVariance;
-            Types::StatisticalDouble ipSqrtVariance;
-            Types::StatisticalDouble ipStandardDeviation;
-            Types::StatisticalDouble ipSqrtStandardDeviation;
-            Types::StatisticalDouble ipSkewnessOfDataset;
-            Types::StatisticalDouble ipSqrtSkewnessOfDataset;
-            Types::StatisticalDouble ipExcessKurtosisOfDataset;
-            Types::StatisticalDouble ipSqrtExcessKurtosisOfDataset;
-            double ipMeanSquareError;
-            double ipSqrtMeanSquareError;
-            double ipRange;
-            double ipSqrtRange;
-            double ipIntervalLength;
-            double ipSqrtIntervalLength;
-            std::vector<double> ipIntervalMinimum;
-            std::vector<double> ipSqrtIntervalMinimum;
-            std::vector<double> ipIntervalMaximum;
-            std::vector<double> ipSqrtIntervalMaximum;
-            std::vector<double> ipIntervalCenter;
-            std::vector<double> ipSqrtIntervalCenter;
+            Types::StatisticalFloat128 ipAverage;
+            Types::StatisticalFloat128 ipSqrtAverage;
+            Types::StatisticalFloat128 ipVariance;
+            Types::StatisticalFloat128 ipSqrtVariance;
+            Types::StatisticalFloat128 ipStandardDeviation;
+            Types::StatisticalFloat128 ipSqrtStandardDeviation;
+            Types::StatisticalFloat128 ipSkewnessOfDataset;
+            Types::StatisticalFloat128 ipSqrtSkewnessOfDataset;
+            Types::StatisticalFloat128 ipExcessKurtosisOfDataset;
+            Types::StatisticalFloat128 ipSqrtExcessKurtosisOfDataset;
+            float128 ipMeanSquareError;
+            float128 ipSqrtMeanSquareError;
+            float128 ipRange;
+            float128 ipSqrtRange;
+            float128 ipIntervalLength;
+            float128 ipSqrtIntervalLength;
+            std::vector<float128> ipIntervalMinimum;
+            std::vector<float128> ipSqrtIntervalMinimum;
+            std::vector<float128> ipIntervalMaximum;
+            std::vector<float128> ipSqrtIntervalMaximum;
+            std::vector<float128> ipIntervalCenter;
+            std::vector<float128> ipSqrtIntervalCenter;
             std::vector<Types::StatisticalUInt64> ipIntervalCount;
             std::vector<Types::StatisticalUInt64> ipSqrtIntervalCount;
         };

--- a/src/acl_data.h
+++ b/src/acl_data.h
@@ -20,7 +20,6 @@
 #include <map>
 
 #include "acl_mtrandom.h"
-#include "acl_global.h"
 #include "acl_float.h"
 
 namespace ACL
@@ -56,11 +55,6 @@ namespace ACL
                 }
                 explicit AtomicUInt64(std::atomic<uint64_t> const &a) : atomic(a.load())
                 {
-                }
-
-                QString toString()
-                {
-                    return QString::number(atomic);
                 }
 
                 AtomicUInt64 &operator= (AtomicUInt64 const &other)

--- a/src/acl_data.h
+++ b/src/acl_data.h
@@ -183,18 +183,18 @@ namespace ACL
             struct CalculationThreadShared
             {
                 MTRandom *random;
-                /* 'atomsUsed' represents an array of 118
-                 * values; each of them represents the number
-                 * of already chosen atomic weights for a
-                 * single chemical element.
+                /* 'atomsUsed' represents an array with the
+                 * numbers of already choosen atomic weights
+                 * of a single chemical element.
                  */
                 std::vector<Types::AtomicUInt64> *atomsUsed;
                 /* 'runningThreads' represents the number of active
                  * calculation threads. When single thread's destructor
                  * is called, it decrements this number by 1. In case
-                 * it is equal to 0, all shared pointers are deallocated.
+                 * the value is equal to 0, all shared pointers are
+                 * deallocated.
                  */
-                int *runningThreads;
+                int *runningThreads; /* <- TODO: Use smart pointers instead. */
             };
         }
         struct CalculationInput

--- a/src/acl_data.h
+++ b/src/acl_data.h
@@ -15,16 +15,13 @@
 /* The number of oxides used in Agemarker calculations */
 #define OXIDES_COUNT            53
 
-#include <boost/multiprecision/float128.hpp>
-
 #include <atomic>
 #include <vector>
 #include <map>
 
 #include "acl_mtrandom.h"
 #include "acl_global.h"
-
-using namespace boost::multiprecision;
+#include "acl_float.h"
 
 namespace ACL
 {
@@ -152,17 +149,17 @@ namespace ACL
                     return *this;
                 }
             };
+            /* typedefs */
             typedef StatisticalValue<uint64_t> StatisticalUInt64;
-            typedef StatisticalValue<float128> StatisticalFloat128;
-
-            typedef std::map<float128, uint64_t> IpValuesMap;
+            typedef StatisticalValue<Float> StatisticalFloat;
+            typedef std::map<Float, uint64_t> IpValuesMap;
         }
         /* Data structs used _internally_ in Agemarker Core Library. */
         namespace Structs
         {
             struct CalculationAtomData
             {
-                std::vector<float128> elementsNewContent;
+                std::vector<Float> elementsNewContent;
                 std::vector<uint64_t> allEight;
                 std::vector<uint64_t> all;
                 uint64_t allEightSum = 0;
@@ -170,7 +167,7 @@ namespace ACL
             };
             struct CalculationThreadInput
             {
-                std::vector<float128> elementsWeight;
+                std::vector<Float> elementsWeight;
                 std::vector<uint64_t> atomAllEight;
                 Logarithm logarithm;
                 uint64_t atomAllEightSum;
@@ -197,9 +194,9 @@ namespace ACL
         }
         struct CalculationInput
         {
-            std::vector<float128> oxidesContent;
-            std::vector<float128> elementsContent;
-            std::vector<float128> elementsWeight;
+            std::vector<Float> oxidesContent;
+            std::vector<Float> elementsContent;
+            std::vector<Float> elementsWeight;
             int decimalPrecision;
             uint64_t multiplier;
             int intervalsNumber;
@@ -211,33 +208,33 @@ namespace ACL
         {
             CalculationInput calculationInput;
             std::vector<uint64_t> atoms;
-            std::vector<float128> ip;
-            std::vector<float128> ipSqrt;
+            std::vector<Float> ip;
+            std::vector<Float> ipSqrt;
             std::vector<uint64_t> ipFrequency;
             std::vector<uint64_t> ipTheoreticalFrequency;
             uint64_t atomsSum;
-            Types::StatisticalFloat128 ipAverage;
-            Types::StatisticalFloat128 ipSqrtAverage;
-            Types::StatisticalFloat128 ipVariance;
-            Types::StatisticalFloat128 ipSqrtVariance;
-            Types::StatisticalFloat128 ipStandardDeviation;
-            Types::StatisticalFloat128 ipSqrtStandardDeviation;
-            Types::StatisticalFloat128 ipSkewnessOfDataset;
-            Types::StatisticalFloat128 ipSqrtSkewnessOfDataset;
-            Types::StatisticalFloat128 ipExcessKurtosisOfDataset;
-            Types::StatisticalFloat128 ipSqrtExcessKurtosisOfDataset;
-            float128 ipMeanSquareError;
-            float128 ipSqrtMeanSquareError;
-            float128 ipRange;
-            float128 ipSqrtRange;
-            float128 ipIntervalLength;
-            float128 ipSqrtIntervalLength;
-            std::vector<float128> ipIntervalMinimum;
-            std::vector<float128> ipSqrtIntervalMinimum;
-            std::vector<float128> ipIntervalMaximum;
-            std::vector<float128> ipSqrtIntervalMaximum;
-            std::vector<float128> ipIntervalCenter;
-            std::vector<float128> ipSqrtIntervalCenter;
+            Types::StatisticalFloat ipAverage;
+            Types::StatisticalFloat ipSqrtAverage;
+            Types::StatisticalFloat ipVariance;
+            Types::StatisticalFloat ipSqrtVariance;
+            Types::StatisticalFloat ipStandardDeviation;
+            Types::StatisticalFloat ipSqrtStandardDeviation;
+            Types::StatisticalFloat ipSkewnessOfDataset;
+            Types::StatisticalFloat ipSqrtSkewnessOfDataset;
+            Types::StatisticalFloat ipExcessKurtosisOfDataset;
+            Types::StatisticalFloat ipSqrtExcessKurtosisOfDataset;
+            Float ipMeanSquareError;
+            Float ipSqrtMeanSquareError;
+            Float ipRange;
+            Float ipSqrtRange;
+            Float ipIntervalLength;
+            Float ipSqrtIntervalLength;
+            std::vector<Float> ipIntervalMinimum;
+            std::vector<Float> ipSqrtIntervalMinimum;
+            std::vector<Float> ipIntervalMaximum;
+            std::vector<Float> ipSqrtIntervalMaximum;
+            std::vector<Float> ipIntervalCenter;
+            std::vector<Float> ipSqrtIntervalCenter;
             std::vector<Types::StatisticalUInt64> ipIntervalCount;
             std::vector<Types::StatisticalUInt64> ipSqrtIntervalCount;
         };

--- a/src/acl_data.h
+++ b/src/acl_data.h
@@ -45,12 +45,23 @@ namespace ACL
             {
                 std::atomic<uint64_t> atomic;
 
-                AtomicUInt64() : atomic(uint64_t()) {}
+                AtomicUInt64() : atomic(uint64_t())
+                {
+                }
+                AtomicUInt64(AtomicUInt64 const &other) : atomic(other.atomic.load())
+                {
+                }
+                explicit AtomicUInt64(uint64_t const &v) : atomic(v)
+                {
+                }
+                explicit AtomicUInt64(std::atomic<uint64_t> const &a) : atomic(a.load())
+                {
+                }
 
-                explicit AtomicUInt64(uint64_t const &v) : atomic(v) {}
-                explicit AtomicUInt64(std::atomic<uint64_t> const &a) : atomic(a.load()) {}
-
-                AtomicUInt64(AtomicUInt64 const &other) : atomic(other.atomic.load()) {}
+                QString toString()
+                {
+                    return QString::number(atomic);
+                }
 
                 AtomicUInt64 &operator= (AtomicUInt64 const &other)
                 {
@@ -178,12 +189,12 @@ namespace ACL
             struct CalculationThreadShared
             {
                 MTRandom *random;
-                /* 'atomsUsed' points to the array of 118
+                /* 'atomsUsed' represents an array of 118
                  * values; each of them represents the number
                  * of already chosen atomic weights for a
                  * single chemical element.
                  */
-                Types::AtomicUInt64 *atomsUsed;
+                std::vector<Types::AtomicUInt64> *atomsUsed;
                 /* 'runningThreads' represents the number of active
                  * calculation threads. When single thread's destructor
                  * is called, it decrements this number by 1. In case

--- a/src/acl_float.h
+++ b/src/acl_float.h
@@ -132,7 +132,7 @@ namespace ACL
                  * can handle, but we take extra precaution
                  * and settle on 30 decimal places.
                  */
-                return toStr(v, 12);
+                return toStr(v, 30);
             }
 #endif
     };

--- a/src/acl_float.h
+++ b/src/acl_float.h
@@ -9,546 +9,126 @@
 #ifndef ACL_FLOAT
 #define ACL_FLOAT
 
-#include <boost/shared_ptr.hpp>
 #include <boost/multiprecision/float128.hpp>
 
-/* Float-to-string conversion */
+/* Float <-> QString conversion */
+#include <QLocale>
 #include <QString>
 #include <sstream>
 #include <string>
 
 #include "acl_global.h"
 
+#ifdef USING_DOUBLE
+#define Float double
+#elif USING_FLOAT128
+#define Float boost::multiprecision::float128
+#endif
+
 namespace ACL
 {
     using namespace boost::multiprecision;
-    /* For certain types of calculations, extended precision (provided
-     * by "float128") is required. In the majority of cases, however,
-     * the precision of "double" is quite enough.
-     * Since the quadruple-precision format noticeably slows down
-     * computations (sometimes up to 4 times - we measured :) ),
-     * there should be a "hybrid" data type that would allow to use
-     * either "float128" or "double" depending on the input data.
-     */
-    class AGEMARKERCORESHARED_EXPORT Float
+    class AGEMARKERCORESHARED_EXPORT FMath
     {
-        /* A quick Google search didn't yield any pre-made
-         * solutions, so we have to invent something resembling
-         * a wheel here.
-         *
-         * The smart pointers are used only as not to store two
-         * scoped variables (both "double" and "float128") in memory
-         * at the same time.
-         *
-         * TODO: Clean up.
-         */
         public:
-            Float()
+#ifdef USING_DOUBLE
+            static double round(double v)
             {
-                /* The default data type is double */
-                this->valueD.reset(new double);
+                return std::round(v);
             }
-            Float(float128 f128)
+            static double round(double v, int precision)
             {
-                this->valueF128.reset(new float128);
-                *this->valueF128 = f128;
+                return std::ceil((v * std::pow(10, precision)) - 0.49)
+                        / std::pow(10, precision);
             }
-            Float(double d)
+            static double sqrt(double v)
             {
-                this->valueD.reset(new double);
-                *this->valueD = d;
+                 return std::sqrt(v);
             }
-            Float(QString string, int precision)
+            static double abs(double v)
             {
-                setPrecision(precision);
-                if (isDouble() == true)
-                {
-                    *this->valueD = string.toDouble();
-                }
-                else
-                {
-                    *this->valueF128 = boost::numeric_cast<float128>
-                                       (string.toStdString());
-                }
+                return std::abs(v);
             }
-            bool isDouble() const
+            static double log(double v)
             {
-                if (valueD)
-                {
-                    return true;
-                }
-                return false;
+                return std::log(v);
             }
-            float128 getF128() const
+            static double log10(double v)
             {
-                return *valueF128;
+                return std::log10(v);
             }
-            double getDouble() const
+            template <typename T>
+            static double pow(double v, T raise)
             {
-                return *valueD;
+                return std::pow(v, raise);
             }
-            void setPrecision(int precision)
+            static double fromStr(QString source)
             {
-                /* According to some testing, 12 is the maximum
-                 * number of decimal places "double" handles without
-                 * losing precision. */
-                if (precision > 12)
-                {
-                    valueF128.reset(new float128);
-                    valueD.reset();
-                }
-                else
-                {
-                    valueD.reset(new double);
-                    valueF128.reset();
-                }
+                return QLocale::system().toDouble(source);
             }
-            QString toString(int precision)
+            static QString toStr(double v, int precision)
             {
                 std::ostringstream s;
-                if (isDouble() == true)
-                {
-                    s << std::setprecision(precision) << getDouble();
-                }
-                else
-                {
-                    s << std::setprecision(precision) << getF128();
-                }
+                s << std::setprecision(precision) << v;
                 return QString::fromStdString(s.str());
-
-                /* QLocale::system().toString(); ? */
             }
-            QString toString()
+            static QString toStr(double v)
             {
-                /* 30 is the default precision for Agemarker
-                 * (maximum limitation of "float128" type is
-                 * 34 decimal places, but we take extra precaution)
+                /* 12 is the maximum safe precision the
+                 * "double" type is able to handle. */
+                return toStr(v, 12);
+            }
+#elif USING_FLOAT128
+            static float128 round(float128 v)
+            {
+                return boost::multiprecision::round(v);
+            }
+            static float128 round(float128 v, int precision)
+            {
+                return boost::multiprecision::ceil((v * std::pow(10, precision)) - 0.49Q)
+                        / std::pow(10, precision);
+            }
+            static float128 sqrt(float128 v)
+            {
+                 return boost::multiprecision::sqrt(v);
+            }
+            static float128 abs(float128 v)
+            {
+                return boost::multiprecision::abs(v);
+            }
+            static float128 log(float128 v)
+            {
+                return boost::multiprecision::log(v);
+            }
+            static float128 log10(float128 v)
+            {
+                return boost::multiprecision::log10(v);
+            }
+            template <typename T>
+            static float128 pow(float128 v, T raise)
+            {
+                return boost::multiprecision::pow(v, raise);
+            }
+            static float128 fromStr(QString source)
+            {
+                return boost::numeric_cast<float128>(source.toStdString());
+            }
+            static QString toStr(float128 v, int precision)
+            {
+                std::ostringstream s;
+                s << std::setprecision(precision) << v;
+                return QString::fromStdString(s.str());
+            }
+            static QString toStr(float128 v)
+            {
+                /* 34 is the maximum precision "float128"
+                 * can handle, but we take extra precaution
+                 * and settle on 30 decimal places.
                  */
-                return toString(30);
+                return toStr(v, 12);
             }
-            inline Float operator += (Float v)
-            {
-                if (isDouble() == true)
-                {
-                    if (v.isDouble() == true)
-                    {
-                        *this->valueD += *v.valueD;
-                    }
-                    else
-                    {
-                        *this->valueD += boost::numeric_cast<double>
-                                         (*v.valueF128);
-                    }
-                }
-                else
-                {
-                    if (v.isDouble() == true)
-                    {
-                        *this->valueF128 += *v.valueD;
-                    }
-                    else
-                    {
-                        *this->valueF128 += *v.valueF128;
-                    }
-                }
-                return *this;
-            }
-            template <typename T>
-            inline Float operator += (T v)
-            {
-                if (isDouble() == true)
-                {
-                    *this->valueD += boost::numeric_cast<double>(v);
-                }
-                else
-                {
-                    *this->valueF128 += v;
-                }
-                return *this;
-            }
-            inline Float operator + (Float v)
-            {
-                if (isDouble() == true)
-                {
-                    if (v.isDouble() == true)
-                    {
-                        return *this->valueD + *v.valueD;
-                    }
-                    else
-                    {
-                        return *this->valueD + boost::numeric_cast<double>
-                                               (*v.valueF128);
-                    }
-                }
-                else
-                {
-                    if (v.isDouble() == true)
-                    {
-                        return *this->valueF128 + *v.valueD;
-                    }
-                    else
-                    {
-                        return *this->valueF128 + *v.valueF128;
-                    }
-                }
-            }
-            template <typename T>
-            inline Float operator + (T v)
-            {
-                if (isDouble() == true)
-                {
-                    return *this->valueD + boost::numeric_cast<double>(v);
-                }
-                else
-                {
-                    return *this->valueF128 + v;
-                }
-            }
-            inline Float operator - (Float v)
-            {
-                if (isDouble() == true)
-                {
-                    if (v.isDouble() == true)
-                    {
-                        return *this->valueD - *v.valueD;
-                    }
-                    else
-                    {
-                        return *this->valueD - boost::numeric_cast<double>
-                                               (*v.valueF128);
-                    }
-                }
-                else
-                {
-                    if (v.isDouble() == true)
-                    {
-                        return *this->valueF128 - *v.valueD;
-                    }
-                    else
-                    {
-                        return *this->valueF128 - *v.valueF128;
-                    }
-                }
-            }
-            template <typename T>
-            inline Float operator - (T v)
-            {
-                if (isDouble() == true)
-                {
-                    return *this->valueD - boost::numeric_cast<double>(v);
-                }
-                else
-                {
-                    return *this->valueF128 - v;
-                }
-            }
-            inline Float operator * (Float v)
-            {
-                if (isDouble() == true)
-                {
-                    if (v.isDouble() == true)
-                    {
-                        return *this->valueD * *v.valueD;
-                    }
-                    else
-                    {
-                        return *this->valueD * boost::numeric_cast<double>
-                                               (*v.valueF128);
-                    }
-                }
-                else
-                {
-                    if (v.isDouble() == true)
-                    {
-                        return *this->valueF128 * *v.valueD;
-                    }
-                    else
-                    {
-                        return *this->valueF128 * *v.valueF128;
-                    }
-                }
-            }
-            template <typename T>
-            inline Float operator * (T v)
-            {
-                if (isDouble() == true)
-                {
-                    return *this->valueD * boost::numeric_cast<double>(v);
-                }
-                else
-                {
-                    return *this->valueF128 * v;
-                }
-            }
-            inline Float operator / (Float v)
-            {
-                if (isDouble() == true)
-                {
-                    if (v.isDouble() == true)
-                    {
-                        return *this->valueD / *v.valueD;
-                    }
-                    else
-                    {
-                        return *this->valueD / boost::numeric_cast<double>
-                                               (*v.valueF128);
-                    }
-                }
-                else
-                {
-                    if (v.isDouble() == true)
-                    {
-                        return *this->valueF128 / *v.valueD;
-                    }
-                    else
-                    {
-                        return *this->valueF128 / *v.valueF128;
-                    }
-                }
-            }
-            template <typename T>
-            inline Float operator / (T v)
-            {
-                if (isDouble() == true)
-                {
-                    return *this->valueD / boost::numeric_cast<double>(v);
-                }
-                else
-                {
-                    return *this->valueF128 / v;
-                }
-            }
-            inline Float operator = (Float v)
-            {
-                if (isDouble() == true)
-                {
-                    if (v.isDouble() == true)
-                    {
-                        *this->valueD = *v.valueD;
-                    }
-                    else
-                    {
-                        *this->valueD = boost::numeric_cast<double>
-                                        (*v.valueF128);
-                    }
-                }
-                else
-                {
-                    if (v.isDouble() == true)
-                    {
-                        *this->valueF128 = *v.valueD;
-                    }
-                    else
-                    {
-                        *this->valueF128 = *v.valueF128;
-                    }
-                }
-                return *this;
-            }
-            inline Float operator = (float128 v)
-            {
-                if (isDouble() == true)
-                {
-                    *this->valueD = boost::numeric_cast<double>(v);
-                }
-                else
-                {
-                    *this->valueF128 = v;
-                }
-                return *this;
-            }
-            inline Float operator = (double v)
-            {
-                if (isDouble() == true)
-                {
-                    *this->valueD = v;
-                }
-                else
-                {
-                    *this->valueF128 = v;
-                }
-                return *this;
-            }
-            inline bool operator < (const Float& other) const
-            {
-                if (isDouble() == true)
-                {
-                    if (other.isDouble() == true)
-                    {
-                        return getDouble() < other.getDouble();
-                    }
-                    return getDouble() < other.getF128();
-                }
-                else
-                {
-                    if (other.isDouble() == true)
-                    {
-                        return getF128() < other.getDouble();
-                    }
-                    return getF128() < other.getF128();
-                }
-            }
-            inline bool operator > (const Float& other) const
-            {
-                if (isDouble() == true)
-                {
-                    if (other.isDouble() == true)
-                    {
-                        return getDouble() > other.getDouble();
-                    }
-                    return getDouble() > other.getF128();
-                }
-                else
-                {
-                    if (other.isDouble() == true)
-                    {
-                        return getF128() > other.getDouble();
-                    }
-                    return getF128() > other.getF128();
-                }
-            }
-            inline bool operator <= (const Float& other) const
-            {
-                if (isDouble() == true)
-                {
-                    if (other.isDouble() == true)
-                    {
-                        return getDouble() <= other.getDouble();
-                    }
-                    return getDouble() <= other.getF128();
-                }
-                else
-                {
-                    if (other.isDouble() == true)
-                    {
-                        return getF128() <= other.getDouble();
-                    }
-                    return getF128() <= other.getF128();
-                }
-            }
-            inline bool operator >= (const Float& other) const
-            {
-                if (isDouble() == true)
-                {
-                    if (other.isDouble() == true)
-                    {
-                        return getDouble() >= other.getDouble();
-                    }
-                    return getDouble() >= other.getF128();
-                }
-                else
-                {
-                    if (other.isDouble() == true)
-                    {
-                        return getF128() >= other.getDouble();
-                    }
-                    return getF128() >= other.getF128();
-                }
-            }
-            template <typename T>
-            inline bool operator == (const T& other)
-            {
-                if (isDouble() == true)
-                {
-                    return getDouble() == other;
-                }
-                return getF128() == other;
-            }
-            template <typename T>
-            inline bool operator != (const T& other)
-            {
-                if (isDouble() == true)
-                {
-                    return getDouble() != other;
-                }
-                return getF128() != other;
-            }
-
-        private:
-            boost::shared_ptr<boost::multiprecision::float128> valueF128 =
-                    boost::shared_ptr<boost::multiprecision::float128>(nullptr);
-            boost::shared_ptr<double> valueD =
-                    boost::shared_ptr<double>(nullptr);
+#endif
     };
-
-    /* Due to the way Float is implemented at the moment,
-     * it is impossible to use most of the standard math functions
-     * (pow, sqrt, log, abs, etc.) directly, without checking
-     * the type of variable used.
-     * Therefore, we use a dedicated class.
-     */
-     class AGEMARKERCORESHARED_EXPORT FMath
-     {
-         public:
-             static Float round(Float v)
-             {
-                if (v.isDouble() == true)
-                {
-                    return Float(std::round(v.getDouble()));
-                }
-                return Float(boost::multiprecision::round(v.getF128()));
-             }
-             static Float round(Float v, int precision)
-             {
-                if (v.isDouble() == true)
-                {
-                    return Float(std::ceil((v.getDouble() * std::pow(10, precision)) - 0.49)
-                                 / std::pow(10, precision));
-                }
-                return Float(boost::multiprecision::ceil((v.getF128() * std::pow(10, precision)) - 0.49Q)
-                             / std::pow(10, precision));
-             }
-             template <typename T>
-             static Float pow(Float v, T raise)
-             {
-                 if (v.isDouble() == true)
-                 {
-                     return Float(std::pow(v.getDouble(), raise));
-                 }
-                 return Float(boost::multiprecision::pow(v.getF128(), raise));
-             }
-             static Float sqrt(Float v)
-             {
-                 if (v.isDouble() == true)
-                 {
-                     return Float(std::sqrt(v.getDouble()));
-                 }
-                 return Float(boost::multiprecision::sqrt(v.getF128()));
-             }
-             static Float abs(Float v)
-             {
-                 if (v.isDouble() == true)
-                 {
-                     return Float(std::abs(v.getDouble()));
-                 }
-                 return Float(boost::multiprecision::abs(v.getF128()));
-             }
-             static Float log(Float v)
-             {
-                 if (v.isDouble() == true)
-                 {
-                     return Float(std::log(v.getDouble()));
-                 }
-                 return Float(boost::multiprecision::log(v.getF128()));
-             }
-             static Float log10(Float v)
-             {
-                 if (v.isDouble() == true)
-                 {
-                     return Float(std::log10(v.getDouble()));
-                 }
-                 return Float(boost::multiprecision::log10(v.getF128()));
-             }
-             template <typename T>
-             static T boost_numeric_cast(Float v)
-             {
-                 if (v.isDouble() == true)
-                 {
-                     return boost::numeric_cast<T>(v.getDouble());
-                 }
-                 return boost::numeric_cast<T>(v.getF128());
-             }
-     };
 }
 
 #endif // ACL_FLOAT

--- a/src/acl_float.h
+++ b/src/acl_float.h
@@ -159,26 +159,25 @@ namespace ACL
                 {
                     if (v.isDouble() == true)
                     {
-                        *this->valueD += *v.valueD;
+                        return *this->valueD + *v.valueD;
                     }
                     else
                     {
-                        *this->valueD += boost::numeric_cast<double>
-                                         (*v.valueF128);
+                        return *this->valueD + boost::numeric_cast<double>
+                                               (*v.valueF128);
                     }
                 }
                 else
                 {
                     if (v.isDouble() == true)
                     {
-                        *this->valueF128 += *v.valueD;
+                        return *this->valueF128 + *v.valueD;
                     }
                     else
                     {
-                        *this->valueF128 += *v.valueF128;
+                        return *this->valueF128 + *v.valueF128;
                     }
                 }
-                return *this;
             }
             inline Float operator - (Float v)
             {
@@ -186,26 +185,25 @@ namespace ACL
                 {
                     if (v.isDouble() == true)
                     {
-                        *this->valueD -= *v.valueD;
+                        return *this->valueD - *v.valueD;
                     }
                     else
                     {
-                        *this->valueD -= boost::numeric_cast<double>
-                                         (*v.valueF128);
+                        return *this->valueD - boost::numeric_cast<double>
+                                               (*v.valueF128);
                     }
                 }
                 else
                 {
                     if (v.isDouble() == true)
                     {
-                        *this->valueF128 -= *v.valueD;
+                        return *this->valueF128 - *v.valueD;
                     }
                     else
                     {
-                        *this->valueF128 -= *v.valueF128;
+                        return *this->valueF128 - *v.valueF128;
                     }
                 }
-                return *this;
             }
             inline Float operator * (Float v)
             {
@@ -213,26 +211,25 @@ namespace ACL
                 {
                     if (v.isDouble() == true)
                     {
-                        *this->valueD *= *v.valueD;
+                        return *this->valueD * *v.valueD;
                     }
                     else
                     {
-                        *this->valueD *= boost::numeric_cast<double>
-                                         (*v.valueF128);
+                        return *this->valueD * boost::numeric_cast<double>
+                                               (*v.valueF128);
                     }
                 }
                 else
                 {
                     if (v.isDouble() == true)
                     {
-                        *this->valueF128 *= *v.valueD;
+                        return *this->valueF128 * *v.valueD;
                     }
                     else
                     {
-                        *this->valueF128 *= *v.valueF128;
+                        return *this->valueF128 * *v.valueF128;
                     }
                 }
-                return *this;
             }
             inline Float operator / (Float v)
             {
@@ -240,26 +237,25 @@ namespace ACL
                 {
                     if (v.isDouble() == true)
                     {
-                        *this->valueD /= *v.valueD;
+                        return *this->valueD / *v.valueD;
                     }
                     else
                     {
-                        *this->valueD /= boost::numeric_cast<double>
-                                         (*v.valueF128);
+                        return *this->valueD / boost::numeric_cast<double>
+                                               (*v.valueF128);
                     }
                 }
                 else
                 {
                     if (v.isDouble() == true)
                     {
-                        *this->valueF128 /= *v.valueD;
+                        return *this->valueF128 / *v.valueD;
                     }
                     else
                     {
-                        *this->valueF128 /= *v.valueF128;
+                        return *this->valueF128 / *v.valueF128;
                     }
                 }
-                return *this;
             }
             inline Float operator = (Float v)
             {

--- a/src/acl_float.h
+++ b/src/acl_float.h
@@ -1,0 +1,505 @@
+/*
+ * Copyright (c) 2013 Mikhail Labushev.
+ *
+ * This file is a part of agemarker-core
+ * library distributed under the MIT License.
+ * For full terms see LICENSE file.
+ */
+
+#ifndef ACL_FLOAT
+#define ACL_FLOAT
+
+#include <boost/multiprecision/float128.hpp>
+
+#include <QString>
+#include <sstream>
+#include <string>
+
+#include "acl_global.h"
+
+namespace ACL
+{
+    using namespace boost::multiprecision;
+    /* For certain types of calculations, extended precision (provided
+     * by "float128") is required. In the majority of cases, however,
+     * the precision of "double" is quite enough.
+     * Since the quadruple-precision format noticeably slows down
+     * computations (sometimes up to 4 times - we measured :) ),
+     * there should be a "hybrid" data type that would allow to use
+     * either "float128" or "double" depending on the input data.
+     */
+    class AGEMARKERCORESHARED_EXPORT Float
+    {
+        /* A quick Google search didn't yield any pre-made
+         * solutions, so we have to invent something resembling
+         * a wheel here.
+         * Pointers make memory-management a headache, but they
+         * seem like an "obvious" solution for type switching.
+         * It is not quite clean, but it works nonetheless.
+         *
+         * Okay, scratch that. The current code is an abomination
+         * and needs to be fixed asap. The pointers are used only
+         * as not to store two scoped variables (both "double"
+         * and "float128") in memory at the same time.
+         * Is all this mess really worth those few bytes?
+         */
+        public:
+            Float()
+            {
+                /* The default data type is double */
+                this->valueD = new double;
+            }
+            Float(float128 f128)
+            {
+                this->valueF128 = new float128;
+                *this->valueF128 = f128;
+            }
+            Float(double d)
+            {
+                this->valueD = new double;
+                *this->valueD = d;
+            }
+            Float(QString string, int precision)
+            {
+                setPrecision(precision);
+                if (isDouble() == true)
+                {
+                    *this->valueD = string.toDouble();
+                }
+                else
+                {
+                    *this->valueF128 = boost::numeric_cast<float128>(string.toStdString());
+                }
+            }
+            ~Float()
+            {
+                if (valueD != nullptr)
+                {
+                    delete valueD;
+                    valueD = nullptr;
+                }
+                if (valueF128 != nullptr)
+                {
+                    delete [] valueF128;
+                    valueF128 = nullptr;
+                }
+            }
+            bool isDouble() const
+            {
+                if (valueD != nullptr)
+                {
+                    return true;
+                }
+                return false;
+            }
+            float128 getF128() const
+            {
+                return *valueF128;
+            }
+            double getDouble() const
+            {
+                return *valueD;
+            }
+            void setPrecision(int precision)
+            {
+                /* According to some testing, 12 is the maximum
+                 * number of decimal places "double" handles without
+                 * losing precision. */
+                if (precision > 12)
+                {
+                    valueF128 = new float128;
+                    if (valueD != nullptr)
+                    {
+                        delete valueD;
+                        valueD = nullptr;
+                    }
+                }
+                else
+                {
+                    this->valueD = new double;
+                    if (valueF128 != nullptr)
+                    {
+                        delete valueF128;
+                        valueF128 = nullptr;
+                    }
+                }
+            }
+            QString toString(int precision)
+            {
+                std::ostringstream s;
+                if (isDouble() == true)
+                {
+                    s << std::setprecision(precision) << getDouble();
+                }
+                else
+                {
+                    s << std::setprecision(precision) << getF128();
+                }
+                return QString::fromStdString(s.str());
+
+                /* QLocale::system().toString(); ? */
+            }
+            QString toString()
+            {
+                /* 30 is the default precision for Agemarker
+                 * (maximum limitation of "float128" type is
+                 * 34 decimal places, but we take extra precaution)
+                 */
+                return toString(30);
+            }
+            inline Float operator += (Float v)
+            {
+                if (isDouble() == true)
+                {
+                    if (v.isDouble() == true)
+                    {
+                        *this->valueD += *v.valueD;
+                    }
+                    else
+                    {
+                        *this->valueD += boost::numeric_cast<double>(*v.valueF128);
+                    }
+                }
+                else
+                {
+                    if (v.isDouble() == true)
+                    {
+                        *this->valueF128 += *v.valueD;
+                    }
+                    else
+                    {
+                        *this->valueF128 += *v.valueF128;
+                    }
+                }
+                return *this;
+            }
+            inline Float operator + (Float v)
+            {
+                if (isDouble() == true)
+                {
+                    if (v.isDouble() == true)
+                    {
+                        *this->valueD += *v.valueD;
+                    }
+                    else
+                    {
+                        *this->valueD += boost::numeric_cast<double>(*v.valueF128);
+                    }
+                }
+                else
+                {
+                    if (v.isDouble() == true)
+                    {
+                        *this->valueF128 += *v.valueD;
+                    }
+                    else
+                    {
+                        *this->valueF128 += *v.valueF128;
+                    }
+                }
+                return *this;
+            }
+            inline Float operator - (Float v)
+            {
+                if (isDouble() == true)
+                {
+                    if (v.isDouble() == true)
+                    {
+                        *this->valueD -= *v.valueD;
+                    }
+                    else
+                    {
+                        *this->valueD -= boost::numeric_cast<double>(*v.valueF128);
+                    }
+                }
+                else
+                {
+                    if (v.isDouble() == true)
+                    {
+                        *this->valueF128 -= *v.valueD;
+                    }
+                    else
+                    {
+                        *this->valueF128 -= *v.valueF128;
+                    }
+                }
+                return *this;
+            }
+            inline Float operator * (Float v)
+            {
+                if (isDouble() == true)
+                {
+                    if (v.isDouble() == true)
+                    {
+                        *this->valueD *= *v.valueD;
+                    }
+                    else
+                    {
+                        *this->valueD *= boost::numeric_cast<double>(*v.valueF128);
+                    }
+                }
+                else
+                {
+                    if (v.isDouble() == true)
+                    {
+                        *this->valueF128 *= *v.valueD;
+                    }
+                    else
+                    {
+                        *this->valueF128 *= *v.valueF128;
+                    }
+                }
+                return *this;
+            }
+            inline Float operator / (Float v)
+            {
+                if (isDouble() == true)
+                {
+                    if (v.isDouble() == true)
+                    {
+                        *this->valueD /= *v.valueD;
+                    }
+                    else
+                    {
+                        *this->valueD /= boost::numeric_cast<double>(*v.valueF128);
+                    }
+                }
+                else
+                {
+                    if (v.isDouble() == true)
+                    {
+                        *this->valueF128 /= *v.valueD;
+                    }
+                    else
+                    {
+                        *this->valueF128 /= *v.valueF128;
+                    }
+                }
+                return *this;
+            }
+            inline Float operator = (Float v)
+            {
+                if (isDouble() == true)
+                {
+                    if (v.isDouble() == true)
+                    {
+                        *this->valueD = *v.valueD;
+                    }
+                    else
+                    {
+                        *this->valueD = boost::numeric_cast<double>(*v.valueF128);
+                    }
+                }
+                else
+                {
+                    if (v.isDouble() == true)
+                    {
+                        *this->valueF128 = *v.valueD;
+                    }
+                    else
+                    {
+                        *this->valueF128 = *v.valueF128;
+                    }
+                }
+                return *this;
+            }
+            inline Float operator = (float128 v)
+            {
+                if (isDouble() == true)
+                {
+                    *this->valueD = boost::numeric_cast<double>(v);
+                }
+                else
+                {
+                    *this->valueF128 = v;
+                }
+                return *this;
+            }
+            inline Float operator = (double v)
+            {
+                if (isDouble() == true)
+                {
+                    *this->valueD = v;
+                }
+                else
+                {
+                    *this->valueF128 = v;
+                }
+                return *this;
+            }
+            inline bool operator < (const Float& other) const
+            {
+                if (isDouble() == true)
+                {
+                    if (other.isDouble() == true)
+                    {
+                        return getDouble() < other.getDouble();
+                    }
+                    return getDouble() < other.getF128();
+                }
+                else
+                {
+                    if (other.isDouble() == true)
+                    {
+                        return getF128() < other.getDouble();
+                    }
+                    return getF128() < other.getF128();
+                }
+            }
+            inline bool operator > (const Float& other) const
+            {
+                if (isDouble() == true)
+                {
+                    if (other.isDouble() == true)
+                    {
+                        return getDouble() > other.getDouble();
+                    }
+                    return getDouble() > other.getF128();
+                }
+                else
+                {
+                    if (other.isDouble() == true)
+                    {
+                        return getF128() > other.getDouble();
+                    }
+                    return getF128() > other.getF128();
+                }
+            }
+            inline bool operator <= (const Float& other) const
+            {
+                if (isDouble() == true)
+                {
+                    if (other.isDouble() == true)
+                    {
+                        return getDouble() <= other.getDouble();
+                    }
+                    return getDouble() <= other.getF128();
+                }
+                else
+                {
+                    if (other.isDouble() == true)
+                    {
+                        return getF128() <= other.getDouble();
+                    }
+                    return getF128() <= other.getF128();
+                }
+            }
+            inline bool operator >= (const Float& other) const
+            {
+                if (isDouble() == true)
+                {
+                    if (other.isDouble() == true)
+                    {
+                        return getDouble() >= other.getDouble();
+                    }
+                    return getDouble() >= other.getF128();
+                }
+                else
+                {
+                    if (other.isDouble() == true)
+                    {
+                        return getF128() >= other.getDouble();
+                    }
+                    return getF128() >= other.getF128();
+                }
+            }
+            template <typename T>
+            inline bool operator == (const T& other)
+            {
+                if (isDouble() == true)
+                {
+                    return getDouble() == other;
+                }
+                return getF128() == other;
+            }
+            template <typename T>
+            inline bool operator != (const T& other)
+            {
+                return !(*this == other);
+            }
+
+        private:
+            float128 *valueF128 = nullptr;
+            double *valueD = nullptr;
+    };
+
+    /* Due to the way Float is implemented at the moment,
+     * it is impossible to use most of the standard math functions
+     * (pow, sqrt, log, abs, etc.) directly, without checking
+     * the type of variable used.
+     * Therefore, we use a dedicated class.
+     */
+     class AGEMARKERCORESHARED_EXPORT FMath
+     {
+         public:
+             static Float round(Float v)
+             {
+                if (v.isDouble() == true)
+                {
+                    return Float(std::round(v.getDouble()));
+                }
+                return Float(boost::multiprecision::round(v.getF128()));
+             }
+             static Float round(Float v, int precision)
+             {
+                if (v.isDouble() == true)
+                {
+                    return Float(std::ceil((v.getDouble() * std::pow(10, precision)) - 0.49) / std::pow(10, precision));
+                }
+                return Float(boost::multiprecision::ceil((v.getF128() * std::pow(10, precision)) - 0.49Q) / std::pow(10, precision));
+             }
+             template <typename T>
+             static Float pow(Float v, T raise)
+             {
+                 if (v.isDouble() == true)
+                 {
+                     return Float(std::pow(v.getDouble(), raise));
+                 }
+                 return Float(boost::multiprecision::pow(v.getF128(), raise));
+             }
+             static Float sqrt(Float v)
+             {
+                 if (v.isDouble() == true)
+                 {
+                     return Float(std::sqrt(v.getDouble()));
+                 }
+                 return Float(boost::multiprecision::sqrt(v.getF128()));
+             }
+             static Float abs(Float v)
+             {
+                 if (v.isDouble() == true)
+                 {
+                     return Float(std::abs(v.getDouble()));
+                 }
+                 return Float(boost::multiprecision::abs(v.getF128()));
+             }
+             static Float log(Float v)
+             {
+                 if (v.isDouble() == true)
+                 {
+                     return Float(std::log(v.getDouble()));
+                 }
+                 return Float(boost::multiprecision::log(v.getF128()));
+             }
+             static Float log10(Float v)
+             {
+                 if (v.isDouble() == true)
+                 {
+                     return Float(std::log10(v.getDouble()));
+                 }
+                 return Float(boost::multiprecision::log10(v.getF128()));
+             }
+             template <typename T>
+             static T boost_numeric_cast(Float v)
+             {
+                 if (v.isDouble() == true)
+                 {
+                     return boost::numeric_cast<T>(v.getDouble());
+                 }
+                 return boost::numeric_cast<T>(v.getF128());
+             }
+     };
+}
+
+#endif // ACL_FLOAT
+

--- a/src/acl_float.h
+++ b/src/acl_float.h
@@ -19,9 +19,15 @@
 
 #include "acl_global.h"
 
+/* Look up "acl_global.h" for USING_DOUBLE and
+ * USING_FLOAT128 definitions (read the Qt Project
+ * file) for more information.
+*/
+
 #ifdef USING_DOUBLE
 #define Float double
-#elif USING_FLOAT128
+#endif
+#ifdef USING_FLOAT128
 #define Float boost::multiprecision::float128
 #endif
 
@@ -78,7 +84,8 @@ namespace ACL
                  * "double" type is able to handle. */
                 return toStr(v, 12);
             }
-#elif USING_FLOAT128
+#endif
+#ifdef USING_FLOAT128
             static float128 round(float128 v)
             {
                 return boost::multiprecision::round(v);

--- a/src/acl_float.h
+++ b/src/acl_float.h
@@ -153,6 +153,19 @@ namespace ACL
                 }
                 return *this;
             }
+            template <typename T>
+            inline Float operator += (T v)
+            {
+                if (isDouble() == true)
+                {
+                    *this->valueD += boost::numeric_cast<double>(v);
+                }
+                else
+                {
+                    *this->valueF128 += v;
+                }
+                return *this;
+            }
             inline Float operator + (Float v)
             {
                 if (isDouble() == true)
@@ -177,6 +190,18 @@ namespace ACL
                     {
                         return *this->valueF128 + *v.valueF128;
                     }
+                }
+            }
+            template <typename T>
+            inline Float operator + (T v)
+            {
+                if (isDouble() == true)
+                {
+                    return *this->valueD + boost::numeric_cast<double>(v);
+                }
+                else
+                {
+                    return *this->valueF128 + v;
                 }
             }
             inline Float operator - (Float v)
@@ -205,6 +230,18 @@ namespace ACL
                     }
                 }
             }
+            template <typename T>
+            inline Float operator - (T v)
+            {
+                if (isDouble() == true)
+                {
+                    return *this->valueD - boost::numeric_cast<double>(v);
+                }
+                else
+                {
+                    return *this->valueF128 - v;
+                }
+            }
             inline Float operator * (Float v)
             {
                 if (isDouble() == true)
@@ -231,6 +268,18 @@ namespace ACL
                     }
                 }
             }
+            template <typename T>
+            inline Float operator * (T v)
+            {
+                if (isDouble() == true)
+                {
+                    return *this->valueD * boost::numeric_cast<double>(v);
+                }
+                else
+                {
+                    return *this->valueF128 * v;
+                }
+            }
             inline Float operator / (Float v)
             {
                 if (isDouble() == true)
@@ -255,6 +304,18 @@ namespace ACL
                     {
                         return *this->valueF128 / *v.valueF128;
                     }
+                }
+            }
+            template <typename T>
+            inline Float operator / (T v)
+            {
+                if (isDouble() == true)
+                {
+                    return *this->valueD / boost::numeric_cast<double>(v);
+                }
+                else
+                {
+                    return *this->valueF128 / v;
                 }
             }
             inline Float operator = (Float v)
@@ -396,7 +457,11 @@ namespace ACL
             template <typename T>
             inline bool operator != (const T& other)
             {
-                return !(*this == other);
+                if (isDouble() == true)
+                {
+                    return getDouble() != other;
+                }
+                return getF128() != other;
             }
 
         private:

--- a/src/acl_global.h
+++ b/src/acl_global.h
@@ -17,4 +17,15 @@
 #  define AGEMARKERCORESHARED_EXPORT Q_DECL_IMPORT
 #endif
 
+/* To compile the library with extended precision floats,
+ * uncomment the following line.
+ */
+//#define USING_FLOAT128
+
+/* To compile the library with standard ("double") precision
+ * floats, uncomment the following line.
+ */
+#define USING_DOUBLE
+
+
 #endif // ACL_AGEMARKERCORE_GLOBAL_H

--- a/src/acl_global.h
+++ b/src/acl_global.h
@@ -20,15 +20,19 @@
 
 /* To compile the library with extended precision floats,
  * uncomment the following line.
- * Note: don't forget to rebuild the "agemarker" project.
+ * Note: don't forget to rebuild the "agemarker" project
+ * _and change the project files of both "agemarker-core" and
+ * "agemarker"_.
  */
-#define USING_FLOAT128
+//#define USING_FLOAT128
 
 /* To compile the library with standard ("double") precision
  * floats, uncomment the following line.
- * Note: don't forget to rebuild the "agemarker" project.
+ * Note: don't forget to rebuild the "agemarker" project
+ * _and change the project files of both "agemarker-core" and
+ * "agemarker"_.
  */
-//#define USING_DOUBLE
+#define USING_DOUBLE
 
 /* See "acl_float.h" for the main implementation
  * (functions / "Float" definitions).

--- a/src/acl_global.h
+++ b/src/acl_global.h
@@ -17,15 +17,22 @@
 #  define AGEMARKERCORESHARED_EXPORT Q_DECL_IMPORT
 #endif
 
+
 /* To compile the library with extended precision floats,
  * uncomment the following line.
+ * Note: don't forget to rebuild the "agemarker" project.
  */
-//#define USING_FLOAT128
+#define USING_FLOAT128
 
 /* To compile the library with standard ("double") precision
  * floats, uncomment the following line.
+ * Note: don't forget to rebuild the "agemarker" project.
  */
-#define USING_DOUBLE
+//#define USING_DOUBLE
+
+/* See "acl_float.h" for the main implementation
+ * (functions / "Float" definitions).
+ */
 
 
 #endif // ACL_AGEMARKERCORE_GLOBAL_H

--- a/src/acl_math.cpp
+++ b/src/acl_math.cpp
@@ -9,20 +9,22 @@
 #include "acl_math.h"
 
 using namespace ACL;
+using namespace boost;
 
-double Math::ip(std::vector<double> input, Data::Logarithm log)
+float128 Math::ip(std::vector<float128> input, Data::Logarithm log)
 {
-    double rowSum[3];
-    double columnSum[3];
-    double rowsTotalSum = 0;
-    double rowsUncertaintyTotal = 0;
-    double columnsUncertaintyTotal = 0;
+    float128 rowSum[3];
+    float128 columnSum[3];
+    float128 rowsTotalSum = 0;
+    float128 rowsUncertaintyTotal = 0;
+    float128 columnsUncertaintyTotal = 0;
     for (int x = 0; x < 3; ++x)
     {
         columnSum[x] = input[x] + input[(x + 3)] + input[(x + 6)];
         rowSum[x] = input[(x * 3)] + input[(x * 3) + 1] + input[(x * 3) + 2];
         rowsTotalSum += rowSum[x];
     }
+
     /* Fill 'rowSum' array with uncertainty values for each row */
     if (log == Data::Logarithm::Natural)
     {
@@ -30,12 +32,12 @@ double Math::ip(std::vector<double> input, Data::Logarithm log)
         {
             if (rowSum[x] > 0)
             {
-                rowSum[x] = std::abs((rowSum[x] / rowsTotalSum) * std::log(rowSum[x] / rowsTotalSum));
+                rowSum[x] = multiprecision::abs((rowSum[x] / rowsTotalSum) * multiprecision::log(rowSum[x] / rowsTotalSum));
                 rowsUncertaintyTotal += rowSum[x];
             }
             if (columnSum[x] > 0)
             {
-                columnSum[x] = std::abs((columnSum[x] / rowsTotalSum) * std::log(columnSum[x] / rowsTotalSum));
+                columnSum[x] = multiprecision::abs((columnSum[x] / rowsTotalSum) * multiprecision::log(columnSum[x] / rowsTotalSum));
                 columnsUncertaintyTotal += columnSum[x];
             }
         }
@@ -46,24 +48,24 @@ double Math::ip(std::vector<double> input, Data::Logarithm log)
         {
             if (rowSum[x] > 0)
             {
-                rowSum[x] = std::abs((rowSum[x] / rowsTotalSum) * std::log10(rowSum[x] / rowsTotalSum));
+                rowSum[x] = multiprecision::abs((rowSum[x] / rowsTotalSum) * multiprecision::log10(rowSum[x] / rowsTotalSum));
                 rowsUncertaintyTotal += rowSum[x];
             }
             if (columnSum[x] > 0)
             {
-                columnSum[x] = std::abs((columnSum[x] / rowsTotalSum) * std::log10(columnSum[x] / rowsTotalSum));
+                columnSum[x] = multiprecision::abs((columnSum[x] / rowsTotalSum) * multiprecision::log10(columnSum[x] / rowsTotalSum));
                 columnsUncertaintyTotal += columnSum[x];
             }
         }
     }
-    double kab = 0;
+    float128 kab = 0;
     if (log == Data::Logarithm::Natural)
     {
         for (int x = 0; x < 9; ++x)
         {
             if (input[x] > 0)
             {
-                kab += std::abs(input[x] / rowsTotalSum * std::log(input[x] / rowsTotalSum));
+                kab += multiprecision::abs(input[x] / rowsTotalSum * multiprecision::log(input[x] / rowsTotalSum));
             }
         }
     }
@@ -73,14 +75,14 @@ double Math::ip(std::vector<double> input, Data::Logarithm log)
         {
             if (input[x] > 0)
             {
-                kab += std::abs(input[x] / rowsTotalSum * std::log10(input[x] / rowsTotalSum));
+                kab += multiprecision::abs(input[x] / rowsTotalSum * multiprecision::log10(input[x] / rowsTotalSum));
             }
         }
     }
     return (rowsUncertaintyTotal + columnsUncertaintyTotal - kab);
 }
 
-double Math::roundDouble(double source, int decimals)
+float128 Math::roundFloat128(float128 source, int decimals)
 {
-    return std::ceil((source * std::pow(10, decimals)) - 0.49L) / std::pow(10, decimals);
+    return multiprecision::ceil((source * std::pow(10, decimals)) - 0.49Q) / std::pow(10, decimals);
 }

--- a/src/acl_math.cpp
+++ b/src/acl_math.cpp
@@ -9,7 +9,6 @@
 #include "acl_math.h"
 
 using namespace ACL;
-using namespace boost;
 
 Float Math::ip(std::vector<Float> input, Data::Logarithm log)
 {

--- a/src/acl_math.cpp
+++ b/src/acl_math.cpp
@@ -11,13 +11,13 @@
 using namespace ACL;
 using namespace boost;
 
-float128 Math::ip(std::vector<float128> input, Data::Logarithm log)
+Float Math::ip(std::vector<Float> input, Data::Logarithm log)
 {
-    float128 rowSum[3];
-    float128 columnSum[3];
-    float128 rowsTotalSum = 0;
-    float128 rowsUncertaintyTotal = 0;
-    float128 columnsUncertaintyTotal = 0;
+    Float rowSum[3];
+    Float columnSum[3];
+    Float rowsTotalSum = 0;
+    Float rowsUncertaintyTotal = 0;
+    Float columnsUncertaintyTotal = 0;
     for (int x = 0; x < 3; ++x)
     {
         columnSum[x] = input[x] + input[(x + 3)] + input[(x + 6)];
@@ -32,12 +32,12 @@ float128 Math::ip(std::vector<float128> input, Data::Logarithm log)
         {
             if (rowSum[x] > 0)
             {
-                rowSum[x] = multiprecision::abs((rowSum[x] / rowsTotalSum) * multiprecision::log(rowSum[x] / rowsTotalSum));
+                rowSum[x] = FMath::abs((rowSum[x] / rowsTotalSum) * FMath::log(rowSum[x] / rowsTotalSum));
                 rowsUncertaintyTotal += rowSum[x];
             }
             if (columnSum[x] > 0)
             {
-                columnSum[x] = multiprecision::abs((columnSum[x] / rowsTotalSum) * multiprecision::log(columnSum[x] / rowsTotalSum));
+                columnSum[x] = FMath::abs((columnSum[x] / rowsTotalSum) * FMath::log(columnSum[x] / rowsTotalSum));
                 columnsUncertaintyTotal += columnSum[x];
             }
         }
@@ -48,24 +48,24 @@ float128 Math::ip(std::vector<float128> input, Data::Logarithm log)
         {
             if (rowSum[x] > 0)
             {
-                rowSum[x] = multiprecision::abs((rowSum[x] / rowsTotalSum) * multiprecision::log10(rowSum[x] / rowsTotalSum));
+                rowSum[x] = FMath::abs((rowSum[x] / rowsTotalSum) * FMath::log10(rowSum[x] / rowsTotalSum));
                 rowsUncertaintyTotal += rowSum[x];
             }
             if (columnSum[x] > 0)
             {
-                columnSum[x] = multiprecision::abs((columnSum[x] / rowsTotalSum) * multiprecision::log10(columnSum[x] / rowsTotalSum));
+                columnSum[x] = FMath::abs((columnSum[x] / rowsTotalSum) * FMath::log10(columnSum[x] / rowsTotalSum));
                 columnsUncertaintyTotal += columnSum[x];
             }
         }
     }
-    float128 kab = 0;
+    Float kab = 0;
     if (log == Data::Logarithm::Natural)
     {
         for (int x = 0; x < 9; ++x)
         {
             if (input[x] > 0)
             {
-                kab += multiprecision::abs(input[x] / rowsTotalSum * multiprecision::log(input[x] / rowsTotalSum));
+                kab += FMath::abs(input[x] / rowsTotalSum * FMath::log(input[x] / rowsTotalSum));
             }
         }
     }
@@ -75,14 +75,9 @@ float128 Math::ip(std::vector<float128> input, Data::Logarithm log)
         {
             if (input[x] > 0)
             {
-                kab += multiprecision::abs(input[x] / rowsTotalSum * multiprecision::log10(input[x] / rowsTotalSum));
+                kab += FMath::abs(input[x] / rowsTotalSum * FMath::log10(input[x] / rowsTotalSum));
             }
         }
     }
     return (rowsUncertaintyTotal + columnsUncertaintyTotal - kab);
-}
-
-float128 Math::roundFloat128(float128 source, int decimals)
-{
-    return multiprecision::ceil((source * std::pow(10, decimals)) - 0.49Q) / std::pow(10, decimals);
 }

--- a/src/acl_math.h
+++ b/src/acl_math.h
@@ -16,9 +16,9 @@ namespace ACL
     class AGEMARKERCORESHARED_EXPORT Math
     {
         public:
-            static double ip(std::vector<double> input,
+            static float128 ip(std::vector<float128> input,
                              Data::Logarithm log);
-            static double roundDouble(double source, int decimals);
+            static float128 roundFloat128(float128 source, int decimals);
     };
 }
 

--- a/src/acl_math.h
+++ b/src/acl_math.h
@@ -16,9 +16,8 @@ namespace ACL
     class AGEMARKERCORESHARED_EXPORT Math
     {
         public:
-            static float128 ip(std::vector<float128> input,
-                             Data::Logarithm log);
-            static float128 roundFloat128(float128 source, int decimals);
+            static Float ip(std::vector<Float> input,
+                            Data::Logarithm log);
     };
 }
 

--- a/src/acl_mtrandom.h
+++ b/src/acl_mtrandom.h
@@ -17,10 +17,8 @@ namespace ACL
     {
         public:
             MTRandom();
-            uint64_t getRandomULongLong(uint64_t minValue, uint64_t maxValue);
-
-        private:
             std::mt19937_64 mtwister_engine;
+            uint64_t getRandomULongLong(uint64_t minValue, uint64_t maxValue);
     };
 }
 

--- a/src/acl_results.cpp
+++ b/src/acl_results.cpp
@@ -10,7 +10,6 @@
 #include "acl_math.h"
 
 using namespace ACL;
-using namespace boost;
 
 Results::Results(Data::CalculationInput inputData, Data::Structs::CalculationAtomData atomData,
                  Data::Types::IpValuesMap ipValues)

--- a/src/acl_results.cpp
+++ b/src/acl_results.cpp
@@ -1,7 +1,16 @@
+/*
+ * Copyright (c) 2013 Mikhail Labushev.
+ *
+ * This file is a part of agemarker-core
+ * library distributed under the MIT License.
+ * For full terms see LICENSE file.
+ */
+
 #include "acl_results.h"
 #include "acl_math.h"
 
 using namespace ACL;
+using namespace boost;
 
 Results::Results(Data::CalculationInput inputData, Data::Structs::CalculationAtomData atomData,
                  Data::Types::IpValuesMap ipValues)
@@ -30,7 +39,7 @@ Data::CalculationResult Results::getCalculationResults()
          iter != this->calculatedIp.end(); ++iter)
     {
         r.ip.push_back(iter->first);
-        r.ipSqrt.push_back(Math::roundDouble(std::sqrt(iter->first), this->data.decimalPrecision));
+        r.ipSqrt.push_back(Math::roundFloat128(multiprecision::sqrt(iter->first), this->data.decimalPrecision));
         r.ipFrequency.push_back(iter->second);
     }
 
@@ -85,8 +94,8 @@ Data::CalculationResult Results::calculateStatistics(ACL::Data::CalculationResul
     uint64_t atomAllSumPopulation = std::accumulate(r.ipTheoreticalFrequency.begin(),
                                                     r.ipTheoreticalFrequency.end(), 0);
 
-    Data::Types::StatisticalDouble ipSum;
-    Data::Types::StatisticalDouble ipSqrtSum;
+    Data::Types::StatisticalFloat128 ipSum;
+    Data::Types::StatisticalFloat128 ipSqrtSum;
 
     for (int x = 0; x < this->numberOfIpValues; ++x)
     {
@@ -104,36 +113,36 @@ Data::CalculationResult Results::calculateStatistics(ACL::Data::CalculationResul
 
     for (int x = 0; x < this->numberOfIpValues; ++x)
     {
-        r.ipSqrtVariance.sample += (std::pow((r.ipSqrt[x] - r.ipSqrtAverage.sample), 2) * r.ipFrequency[x]);
-        r.ipSqrtVariance.population += (std::pow((r.ipSqrt[x] - r.ipSqrtAverage.population), 2) * r.ipTheoreticalFrequency[x]);
+        r.ipSqrtVariance.sample += (multiprecision::pow((r.ipSqrt[x] - r.ipSqrtAverage.sample), 2) * r.ipFrequency[x]);
+        r.ipSqrtVariance.population += (multiprecision::pow((r.ipSqrt[x] - r.ipSqrtAverage.population), 2) * r.ipTheoreticalFrequency[x]);
 
-        r.ipVariance.sample += (std::pow((r.ip[x] - r.ipAverage.sample), 2) * r.ipFrequency[x]);
-        r.ipVariance.population += (std::pow((r.ip[x] - r.ipAverage.population), 2) * r.ipTheoreticalFrequency[x]);
+        r.ipVariance.sample += (multiprecision::pow((r.ip[x] - r.ipAverage.sample), 2) * r.ipFrequency[x]);
+        r.ipVariance.population += (multiprecision::pow((r.ip[x] - r.ipAverage.population), 2) * r.ipTheoreticalFrequency[x]);
 
-        r.ipSqrtSkewnessOfDataset.sample += (std::pow((r.ipSqrt[x] - r.ipSqrtAverage.sample), 3) * r.ipFrequency[x]);
-        r.ipSqrtSkewnessOfDataset.population += (std::pow((r.ipSqrt[x] - r.ipSqrtAverage.population), 3) * r.ipTheoreticalFrequency[x]);
+        r.ipSqrtSkewnessOfDataset.sample += (multiprecision::pow((r.ipSqrt[x] - r.ipSqrtAverage.sample), 3) * r.ipFrequency[x]);
+        r.ipSqrtSkewnessOfDataset.population += (multiprecision::pow((r.ipSqrt[x] - r.ipSqrtAverage.population), 3) * r.ipTheoreticalFrequency[x]);
 
-        r.ipSkewnessOfDataset.sample += (std::pow((r.ip[x] - r.ipAverage.sample), 3) * r.ipFrequency[x]);
-        r.ipSkewnessOfDataset.population += (std::pow((r.ip[x] - r.ipAverage.population), 3) * r.ipTheoreticalFrequency[x]);
+        r.ipSkewnessOfDataset.sample += (multiprecision::pow((r.ip[x] - r.ipAverage.sample), 3) * r.ipFrequency[x]);
+        r.ipSkewnessOfDataset.population += (multiprecision::pow((r.ip[x] - r.ipAverage.population), 3) * r.ipTheoreticalFrequency[x]);
 
-        r.ipSqrtExcessKurtosisOfDataset.sample += (std::pow((r.ipSqrt[x] - r.ipSqrtAverage.sample), 4) * r.ipFrequency[x]);
-        r.ipSqrtExcessKurtosisOfDataset.population += (std::pow((r.ipSqrt[x] - r.ipSqrtAverage.population), 4) * r.ipTheoreticalFrequency[x]);
+        r.ipSqrtExcessKurtosisOfDataset.sample += (multiprecision::pow((r.ipSqrt[x] - r.ipSqrtAverage.sample), 4) * r.ipFrequency[x]);
+        r.ipSqrtExcessKurtosisOfDataset.population += (multiprecision::pow((r.ipSqrt[x] - r.ipSqrtAverage.population), 4) * r.ipTheoreticalFrequency[x]);
 
-        r.ipExcessKurtosisOfDataset.sample += (std::pow((r.ip[x] - r.ipAverage.sample), 4) * r.ipFrequency[x]);
-        r.ipExcessKurtosisOfDataset.population += (std::pow((r.ip[x] - r.ipAverage.population), 4) * r.ipTheoreticalFrequency[x]);
+        r.ipExcessKurtosisOfDataset.sample += (multiprecision::pow((r.ip[x] - r.ipAverage.sample), 4) * r.ipFrequency[x]);
+        r.ipExcessKurtosisOfDataset.population += (multiprecision::pow((r.ip[x] - r.ipAverage.population), 4) * r.ipTheoreticalFrequency[x]);
     }
 
     r.ipSqrtVariance.sample = (r.ipSqrtVariance.sample / (this->atoms.allSum - 1));
-    r.ipSqrtVariance.population = (r.ipSqrtVariance.population / (atomAllSumPopulation - 1));
+    r.ipSqrtVariance.population = (r.ipSqrtVariance.population / atomAllSumPopulation);
 
     r.ipVariance.sample = (r.ipVariance.sample / (this->atoms.allSum - 1));
-    r.ipVariance.population = (r.ipVariance.population / (atomAllSumPopulation - 1));
+    r.ipVariance.population = (r.ipVariance.population / atomAllSumPopulation);
 
-    r.ipSqrtStandardDeviation.sample = std::sqrt(r.ipSqrtVariance.sample);
-    r.ipSqrtStandardDeviation.population = std::sqrt(r.ipSqrtVariance.population);
+    r.ipSqrtStandardDeviation.sample = multiprecision::sqrt(r.ipSqrtVariance.sample);
+    r.ipSqrtStandardDeviation.population = multiprecision::sqrt(r.ipSqrtVariance.population);
 
-    r.ipStandardDeviation.sample = std::sqrt(r.ipVariance.sample);
-    r.ipStandardDeviation.population = std::sqrt(r.ipVariance.population);
+    r.ipStandardDeviation.sample = multiprecision::sqrt(r.ipVariance.sample);
+    r.ipStandardDeviation.population = multiprecision::sqrt(r.ipVariance.population);
 
     r = calculateSkewnessOfDataset(r);
     r = calculateExcessKurtosis(r);
@@ -150,13 +159,13 @@ Data::CalculationResult Results::calculateIntervals(ACL::Data::CalculationResult
 {
     r.ipRange = (r.ip[(this->numberOfIpValues - 1)] - r.ip[0]);
     r.ipIntervalLength = (r.ipRange / this->data.intervalsNumber);
-    r.ipSqrtRange = (std::sqrt(r.ip[(this->numberOfIpValues - 1)]) - std::sqrt(r.ip[0]));
+    r.ipSqrtRange = (multiprecision::sqrt(r.ip[(this->numberOfIpValues - 1)]) - multiprecision::sqrt(r.ip[0]));
     r.ipSqrtIntervalLength = (r.ipSqrtRange / this->data.intervalsNumber);
 
     for (int x = 0; x < this->data.intervalsNumber; ++x)
     {
         r.ipIntervalMinimum.push_back(r.ip[0] + (r.ipIntervalLength * x));
-        r.ipSqrtIntervalMinimum.push_back(std::sqrt(r.ip[0]) + (r.ipSqrtIntervalLength * x));
+        r.ipSqrtIntervalMinimum.push_back(multiprecision::sqrt(r.ip[0]) + (r.ipSqrtIntervalLength * x));
 
         if (x < (this->data.intervalsNumber - 1))
         {
@@ -205,23 +214,17 @@ Data::CalculationResult Results::calculateSkewnessOfDataset(Data::CalculationRes
     uint64_t atomAllSumPopulation = std::accumulate(r.ipTheoreticalFrequency.begin(),
                                                     r.ipTheoreticalFrequency.end(), 0);
 
-    r.ipSqrtSkewnessOfDataset.sample = (r.ipSqrtSkewnessOfDataset.sample / (std::pow(r.ipSqrtStandardDeviation.sample, 3)));
-    r.ipSqrtSkewnessOfDataset.population = (r.ipSqrtSkewnessOfDataset.population / (std::pow(r.ipSqrtStandardDeviation.population, 3)));
-
-    r.ipSkewnessOfDataset.sample = (r.ipSkewnessOfDataset.sample / (std::pow(r.ipStandardDeviation.sample, 3)));
-    r.ipSkewnessOfDataset.population = (r.ipSkewnessOfDataset.population / (std::pow(r.ipStandardDeviation.population, 3)));
-
-    double denom = ((this->atoms.allSum - 1) * (this->atoms.allSum - 2));
-    double fraction = (this->atoms.allSum / denom);
-
-    double denomPopulation = ((atomAllSumPopulation - 1) * (atomAllSumPopulation - 2));
-    double fractionPopulation = (atomAllSumPopulation / denomPopulation);
-
+    r.ipSqrtSkewnessOfDataset.sample = (r.ipSqrtSkewnessOfDataset.sample / (multiprecision::pow(r.ipSqrtStandardDeviation.sample, 3)));
+    r.ipSkewnessOfDataset.sample = (r.ipSkewnessOfDataset.sample / (multiprecision::pow(r.ipStandardDeviation.sample, 3)));
+    float128 denom = ((this->atoms.allSum - 1) * (this->atoms.allSum - 2));
+    float128 fraction = (this->atoms.allSum / denom);
     r.ipSqrtSkewnessOfDataset.sample = (r.ipSqrtSkewnessOfDataset.sample * fraction);
-    r.ipSqrtSkewnessOfDataset.population = (r.ipSqrtSkewnessOfDataset.population * fractionPopulation);
-
     r.ipSkewnessOfDataset.sample = (r.ipSkewnessOfDataset.sample * fraction);
-    r.ipSkewnessOfDataset.population = (r.ipSkewnessOfDataset.population * fractionPopulation);
+
+    r.ipSqrtSkewnessOfDataset.population = (r.ipSqrtSkewnessOfDataset.population / (multiprecision::pow(r.ipSqrtStandardDeviation.population, 3)));
+    r.ipSkewnessOfDataset.population = (r.ipSkewnessOfDataset.population / (multiprecision::pow(r.ipStandardDeviation.population, 3)));
+    r.ipSqrtSkewnessOfDataset.population = (r.ipSqrtSkewnessOfDataset.population / atomAllSumPopulation);
+    r.ipSkewnessOfDataset.population = (r.ipSkewnessOfDataset.population / atomAllSumPopulation);
 
     return r;
 }
@@ -231,49 +234,39 @@ Data::CalculationResult Results::calculateExcessKurtosis(Data::CalculationResult
     uint64_t atomAllSumPopulation = std::accumulate(r.ipTheoreticalFrequency.begin(),
                                                     r.ipTheoreticalFrequency.end(), 0);
 
-    r.ipSqrtExcessKurtosisOfDataset.sample = (r.ipSqrtExcessKurtosisOfDataset.sample / (std::pow(r.ipSqrtStandardDeviation.sample, 4)));
-    r.ipSqrtExcessKurtosisOfDataset.population = (r.ipSqrtExcessKurtosisOfDataset.population / (std::pow(r.ipSqrtStandardDeviation.population, 4)));\
+    r.ipSqrtExcessKurtosisOfDataset.sample = (r.ipSqrtExcessKurtosisOfDataset.sample / (multiprecision::pow(r.ipSqrtStandardDeviation.sample, 4)));
+    r.ipExcessKurtosisOfDataset.sample = (r.ipExcessKurtosisOfDataset.sample / (multiprecision::pow(r.ipStandardDeviation.sample, 4)));
 
-    r.ipExcessKurtosisOfDataset.sample = (r.ipExcessKurtosisOfDataset.sample / (std::pow(r.ipStandardDeviation.sample, 4)));
-    r.ipExcessKurtosisOfDataset.population = (r.ipExcessKurtosisOfDataset.population / (std::pow(r.ipStandardDeviation.population, 4)));
+    float128 x0 = (this->atoms.allSum + 1);
+    float128 x1 = (this->atoms.allSum - 1);
+    float128 x2 = (this->atoms.allSum - 2);
+    float128 x3 = (this->atoms.allSum - 3);
 
-    double x0 = (this->atoms.allSum + 1);
-    double x1 = (this->atoms.allSum - 1);
-    double x2 = (this->atoms.allSum - 2);
-    double x3 = (this->atoms.allSum - 3);
-
-    double num = (this->atoms.allSum * x0);
-    double denom = (x1 * x2 * x3);
-    double fraction = (num / denom);
+    float128 num = (this->atoms.allSum * x0);
+    float128 denom = (x1 * x2 * x3);
+    float128 fraction = (num / denom);
 
     x0 = (atomAllSumPopulation + 1);
     x1 = (atomAllSumPopulation - 1);
     x2 = (atomAllSumPopulation - 2);
     x3 = (atomAllSumPopulation - 3);
 
-    double numPopulation = (atomAllSumPopulation * x0);
-    double denomPopulation = (x1 * x2 * x3);
-    double fractionPopulation = (numPopulation / denomPopulation);
-
     r.ipSqrtExcessKurtosisOfDataset.sample = (r.ipSqrtExcessKurtosisOfDataset.sample * fraction);
-    r.ipSqrtExcessKurtosisOfDataset.population = (r.ipSqrtExcessKurtosisOfDataset.population * fractionPopulation);
-
     r.ipExcessKurtosisOfDataset.sample = (r.ipExcessKurtosisOfDataset.sample * fraction);
-    r.ipExcessKurtosisOfDataset.population = (r.ipExcessKurtosisOfDataset.population * fractionPopulation);
 
     num = (3 * (std::pow((this->atoms.allSum - 1), 2)));
     denom = ((this->atoms.allSum - 2) * (this->atoms.allSum - 3));
     fraction = (num / denom);
 
-    numPopulation = (3 * (std::pow((atomAllSumPopulation - 1), 2)));
-    denomPopulation = ((atomAllSumPopulation - 2) * (atomAllSumPopulation - 3));
-    fractionPopulation = (numPopulation / denomPopulation);
-
     r.ipSqrtExcessKurtosisOfDataset.sample = (r.ipSqrtExcessKurtosisOfDataset.sample - fraction);
-    r.ipSqrtExcessKurtosisOfDataset.population = (r.ipSqrtExcessKurtosisOfDataset.population - fractionPopulation);
-
     r.ipExcessKurtosisOfDataset.sample = (r.ipExcessKurtosisOfDataset.sample - fraction);
-    r.ipExcessKurtosisOfDataset.population = (r.ipExcessKurtosisOfDataset.population - fractionPopulation);
+
+    r.ipSqrtExcessKurtosisOfDataset.population = (r.ipSqrtExcessKurtosisOfDataset.population / (multiprecision::pow(r.ipSqrtStandardDeviation.population, 4)));
+    r.ipExcessKurtosisOfDataset.population = (r.ipExcessKurtosisOfDataset.population / (multiprecision::pow(r.ipStandardDeviation.population, 4)));
+    r.ipSqrtExcessKurtosisOfDataset.population = (r.ipSqrtExcessKurtosisOfDataset.population / atomAllSumPopulation);
+    r.ipExcessKurtosisOfDataset.population = (r.ipExcessKurtosisOfDataset.population / atomAllSumPopulation);
+    r.ipSqrtExcessKurtosisOfDataset.population = (r.ipSqrtExcessKurtosisOfDataset.population - 3);
+    r.ipExcessKurtosisOfDataset.population = (r.ipExcessKurtosisOfDataset.population - 3);
 
     return r;
 }

--- a/src/acl_results.cpp
+++ b/src/acl_results.cpp
@@ -39,7 +39,7 @@ Data::CalculationResult Results::getCalculationResults()
          iter != this->calculatedIp.end(); ++iter)
     {
         r.ip.push_back(iter->first);
-        r.ipSqrt.push_back(Math::roundFloat128(multiprecision::sqrt(iter->first), this->data.decimalPrecision));
+        r.ipSqrt.push_back(FMath::round(FMath::sqrt(iter->first), this->data.decimalPrecision));
         r.ipFrequency.push_back(iter->second);
     }
 
@@ -94,8 +94,8 @@ Data::CalculationResult Results::calculateStatistics(ACL::Data::CalculationResul
     uint64_t atomAllSumPopulation = std::accumulate(r.ipTheoreticalFrequency.begin(),
                                                     r.ipTheoreticalFrequency.end(), 0);
 
-    Data::Types::StatisticalFloat128 ipSum;
-    Data::Types::StatisticalFloat128 ipSqrtSum;
+    Data::Types::StatisticalFloat ipSum;
+    Data::Types::StatisticalFloat ipSqrtSum;
 
     for (int x = 0; x < this->numberOfIpValues; ++x)
     {
@@ -113,23 +113,23 @@ Data::CalculationResult Results::calculateStatistics(ACL::Data::CalculationResul
 
     for (int x = 0; x < this->numberOfIpValues; ++x)
     {
-        r.ipSqrtVariance.sample += (multiprecision::pow((r.ipSqrt[x] - r.ipSqrtAverage.sample), 2) * r.ipFrequency[x]);
-        r.ipSqrtVariance.population += (multiprecision::pow((r.ipSqrt[x] - r.ipSqrtAverage.population), 2) * r.ipTheoreticalFrequency[x]);
+        r.ipSqrtVariance.sample += (FMath::pow((r.ipSqrt[x] - r.ipSqrtAverage.sample), 2) * r.ipFrequency[x]);
+        r.ipSqrtVariance.population += (FMath::pow((r.ipSqrt[x] - r.ipSqrtAverage.population), 2) * r.ipTheoreticalFrequency[x]);
 
-        r.ipVariance.sample += (multiprecision::pow((r.ip[x] - r.ipAverage.sample), 2) * r.ipFrequency[x]);
-        r.ipVariance.population += (multiprecision::pow((r.ip[x] - r.ipAverage.population), 2) * r.ipTheoreticalFrequency[x]);
+        r.ipVariance.sample += (FMath::pow((r.ip[x] - r.ipAverage.sample), 2) * r.ipFrequency[x]);
+        r.ipVariance.population += (FMath::pow((r.ip[x] - r.ipAverage.population), 2) * r.ipTheoreticalFrequency[x]);
 
-        r.ipSqrtSkewnessOfDataset.sample += (multiprecision::pow((r.ipSqrt[x] - r.ipSqrtAverage.sample), 3) * r.ipFrequency[x]);
-        r.ipSqrtSkewnessOfDataset.population += (multiprecision::pow((r.ipSqrt[x] - r.ipSqrtAverage.population), 3) * r.ipTheoreticalFrequency[x]);
+        r.ipSqrtSkewnessOfDataset.sample += (FMath::pow((r.ipSqrt[x] - r.ipSqrtAverage.sample), 3) * r.ipFrequency[x]);
+        r.ipSqrtSkewnessOfDataset.population += (FMath::pow((r.ipSqrt[x] - r.ipSqrtAverage.population), 3) * r.ipTheoreticalFrequency[x]);
 
-        r.ipSkewnessOfDataset.sample += (multiprecision::pow((r.ip[x] - r.ipAverage.sample), 3) * r.ipFrequency[x]);
-        r.ipSkewnessOfDataset.population += (multiprecision::pow((r.ip[x] - r.ipAverage.population), 3) * r.ipTheoreticalFrequency[x]);
+        r.ipSkewnessOfDataset.sample += (FMath::pow((r.ip[x] - r.ipAverage.sample), 3) * r.ipFrequency[x]);
+        r.ipSkewnessOfDataset.population += (FMath::pow((r.ip[x] - r.ipAverage.population), 3) * r.ipTheoreticalFrequency[x]);
 
-        r.ipSqrtExcessKurtosisOfDataset.sample += (multiprecision::pow((r.ipSqrt[x] - r.ipSqrtAverage.sample), 4) * r.ipFrequency[x]);
-        r.ipSqrtExcessKurtosisOfDataset.population += (multiprecision::pow((r.ipSqrt[x] - r.ipSqrtAverage.population), 4) * r.ipTheoreticalFrequency[x]);
+        r.ipSqrtExcessKurtosisOfDataset.sample += (FMath::pow((r.ipSqrt[x] - r.ipSqrtAverage.sample), 4) * r.ipFrequency[x]);
+        r.ipSqrtExcessKurtosisOfDataset.population += (FMath::pow((r.ipSqrt[x] - r.ipSqrtAverage.population), 4) * r.ipTheoreticalFrequency[x]);
 
-        r.ipExcessKurtosisOfDataset.sample += (multiprecision::pow((r.ip[x] - r.ipAverage.sample), 4) * r.ipFrequency[x]);
-        r.ipExcessKurtosisOfDataset.population += (multiprecision::pow((r.ip[x] - r.ipAverage.population), 4) * r.ipTheoreticalFrequency[x]);
+        r.ipExcessKurtosisOfDataset.sample += (FMath::pow((r.ip[x] - r.ipAverage.sample), 4) * r.ipFrequency[x]);
+        r.ipExcessKurtosisOfDataset.population += (FMath::pow((r.ip[x] - r.ipAverage.population), 4) * r.ipTheoreticalFrequency[x]);
     }
 
     r.ipSqrtVariance.sample = (r.ipSqrtVariance.sample / (this->atoms.allSum - 1));
@@ -138,11 +138,11 @@ Data::CalculationResult Results::calculateStatistics(ACL::Data::CalculationResul
     r.ipVariance.sample = (r.ipVariance.sample / (this->atoms.allSum - 1));
     r.ipVariance.population = (r.ipVariance.population / atomAllSumPopulation);
 
-    r.ipSqrtStandardDeviation.sample = multiprecision::sqrt(r.ipSqrtVariance.sample);
-    r.ipSqrtStandardDeviation.population = multiprecision::sqrt(r.ipSqrtVariance.population);
+    r.ipSqrtStandardDeviation.sample = FMath::sqrt(r.ipSqrtVariance.sample);
+    r.ipSqrtStandardDeviation.population = FMath::sqrt(r.ipSqrtVariance.population);
 
-    r.ipStandardDeviation.sample = multiprecision::sqrt(r.ipVariance.sample);
-    r.ipStandardDeviation.population = multiprecision::sqrt(r.ipVariance.population);
+    r.ipStandardDeviation.sample = FMath::sqrt(r.ipVariance.sample);
+    r.ipStandardDeviation.population = FMath::sqrt(r.ipVariance.population);
 
     r = calculateSkewnessOfDataset(r);
     r = calculateExcessKurtosis(r);
@@ -159,13 +159,13 @@ Data::CalculationResult Results::calculateIntervals(ACL::Data::CalculationResult
 {
     r.ipRange = (r.ip[(this->numberOfIpValues - 1)] - r.ip[0]);
     r.ipIntervalLength = (r.ipRange / this->data.intervalsNumber);
-    r.ipSqrtRange = (multiprecision::sqrt(r.ip[(this->numberOfIpValues - 1)]) - multiprecision::sqrt(r.ip[0]));
+    r.ipSqrtRange = (FMath::sqrt(r.ip[(this->numberOfIpValues - 1)]) - FMath::sqrt(r.ip[0]));
     r.ipSqrtIntervalLength = (r.ipSqrtRange / this->data.intervalsNumber);
 
     for (int x = 0; x < this->data.intervalsNumber; ++x)
     {
         r.ipIntervalMinimum.push_back(r.ip[0] + (r.ipIntervalLength * x));
-        r.ipSqrtIntervalMinimum.push_back(multiprecision::sqrt(r.ip[0]) + (r.ipSqrtIntervalLength * x));
+        r.ipSqrtIntervalMinimum.push_back(FMath::sqrt(r.ip[0]) + (r.ipSqrtIntervalLength * x));
 
         if (x < (this->data.intervalsNumber - 1))
         {
@@ -214,15 +214,15 @@ Data::CalculationResult Results::calculateSkewnessOfDataset(Data::CalculationRes
     uint64_t atomAllSumPopulation = std::accumulate(r.ipTheoreticalFrequency.begin(),
                                                     r.ipTheoreticalFrequency.end(), 0);
 
-    r.ipSqrtSkewnessOfDataset.sample = (r.ipSqrtSkewnessOfDataset.sample / (multiprecision::pow(r.ipSqrtStandardDeviation.sample, 3)));
-    r.ipSkewnessOfDataset.sample = (r.ipSkewnessOfDataset.sample / (multiprecision::pow(r.ipStandardDeviation.sample, 3)));
+    r.ipSqrtSkewnessOfDataset.sample = (r.ipSqrtSkewnessOfDataset.sample / (FMath::pow(r.ipSqrtStandardDeviation.sample, 3)));
+    r.ipSkewnessOfDataset.sample = (r.ipSkewnessOfDataset.sample / (FMath::pow(r.ipStandardDeviation.sample, 3)));
     float128 denom = ((this->atoms.allSum - 1) * (this->atoms.allSum - 2));
     float128 fraction = (this->atoms.allSum / denom);
     r.ipSqrtSkewnessOfDataset.sample = (r.ipSqrtSkewnessOfDataset.sample * fraction);
     r.ipSkewnessOfDataset.sample = (r.ipSkewnessOfDataset.sample * fraction);
 
-    r.ipSqrtSkewnessOfDataset.population = (r.ipSqrtSkewnessOfDataset.population / (multiprecision::pow(r.ipSqrtStandardDeviation.population, 3)));
-    r.ipSkewnessOfDataset.population = (r.ipSkewnessOfDataset.population / (multiprecision::pow(r.ipStandardDeviation.population, 3)));
+    r.ipSqrtSkewnessOfDataset.population = (r.ipSqrtSkewnessOfDataset.population / (FMath::pow(r.ipSqrtStandardDeviation.population, 3)));
+    r.ipSkewnessOfDataset.population = (r.ipSkewnessOfDataset.population / (FMath::pow(r.ipStandardDeviation.population, 3)));
     r.ipSqrtSkewnessOfDataset.population = (r.ipSqrtSkewnessOfDataset.population / atomAllSumPopulation);
     r.ipSkewnessOfDataset.population = (r.ipSkewnessOfDataset.population / atomAllSumPopulation);
 
@@ -234,8 +234,8 @@ Data::CalculationResult Results::calculateExcessKurtosis(Data::CalculationResult
     uint64_t atomAllSumPopulation = std::accumulate(r.ipTheoreticalFrequency.begin(),
                                                     r.ipTheoreticalFrequency.end(), 0);
 
-    r.ipSqrtExcessKurtosisOfDataset.sample = (r.ipSqrtExcessKurtosisOfDataset.sample / (multiprecision::pow(r.ipSqrtStandardDeviation.sample, 4)));
-    r.ipExcessKurtosisOfDataset.sample = (r.ipExcessKurtosisOfDataset.sample / (multiprecision::pow(r.ipStandardDeviation.sample, 4)));
+    r.ipSqrtExcessKurtosisOfDataset.sample = (r.ipSqrtExcessKurtosisOfDataset.sample / (FMath::pow(r.ipSqrtStandardDeviation.sample, 4)));
+    r.ipExcessKurtosisOfDataset.sample = (r.ipExcessKurtosisOfDataset.sample / (FMath::pow(r.ipStandardDeviation.sample, 4)));
 
     float128 x0 = (this->atoms.allSum + 1);
     float128 x1 = (this->atoms.allSum - 1);
@@ -261,8 +261,8 @@ Data::CalculationResult Results::calculateExcessKurtosis(Data::CalculationResult
     r.ipSqrtExcessKurtosisOfDataset.sample = (r.ipSqrtExcessKurtosisOfDataset.sample - fraction);
     r.ipExcessKurtosisOfDataset.sample = (r.ipExcessKurtosisOfDataset.sample - fraction);
 
-    r.ipSqrtExcessKurtosisOfDataset.population = (r.ipSqrtExcessKurtosisOfDataset.population / (multiprecision::pow(r.ipSqrtStandardDeviation.population, 4)));
-    r.ipExcessKurtosisOfDataset.population = (r.ipExcessKurtosisOfDataset.population / (multiprecision::pow(r.ipStandardDeviation.population, 4)));
+    r.ipSqrtExcessKurtosisOfDataset.population = (r.ipSqrtExcessKurtosisOfDataset.population / (FMath::pow(r.ipSqrtStandardDeviation.population, 4)));
+    r.ipExcessKurtosisOfDataset.population = (r.ipExcessKurtosisOfDataset.population / (FMath::pow(r.ipStandardDeviation.population, 4)));
     r.ipSqrtExcessKurtosisOfDataset.population = (r.ipSqrtExcessKurtosisOfDataset.population / atomAllSumPopulation);
     r.ipExcessKurtosisOfDataset.population = (r.ipExcessKurtosisOfDataset.population / atomAllSumPopulation);
     r.ipSqrtExcessKurtosisOfDataset.population = (r.ipSqrtExcessKurtosisOfDataset.population - 3);

--- a/src/acl_results.cpp
+++ b/src/acl_results.cpp
@@ -216,8 +216,8 @@ Data::CalculationResult Results::calculateSkewnessOfDataset(Data::CalculationRes
 
     r.ipSqrtSkewnessOfDataset.sample = (r.ipSqrtSkewnessOfDataset.sample / (FMath::pow(r.ipSqrtStandardDeviation.sample, 3)));
     r.ipSkewnessOfDataset.sample = (r.ipSkewnessOfDataset.sample / (FMath::pow(r.ipStandardDeviation.sample, 3)));
-    float128 denom = ((this->atoms.allSum - 1) * (this->atoms.allSum - 2));
-    float128 fraction = (this->atoms.allSum / denom);
+    Float denom = ((this->atoms.allSum - 1) * (this->atoms.allSum - 2));
+    Float fraction = (this->atoms.allSum / denom);
     r.ipSqrtSkewnessOfDataset.sample = (r.ipSqrtSkewnessOfDataset.sample * fraction);
     r.ipSkewnessOfDataset.sample = (r.ipSkewnessOfDataset.sample * fraction);
 
@@ -237,14 +237,14 @@ Data::CalculationResult Results::calculateExcessKurtosis(Data::CalculationResult
     r.ipSqrtExcessKurtosisOfDataset.sample = (r.ipSqrtExcessKurtosisOfDataset.sample / (FMath::pow(r.ipSqrtStandardDeviation.sample, 4)));
     r.ipExcessKurtosisOfDataset.sample = (r.ipExcessKurtosisOfDataset.sample / (FMath::pow(r.ipStandardDeviation.sample, 4)));
 
-    float128 x0 = (this->atoms.allSum + 1);
-    float128 x1 = (this->atoms.allSum - 1);
-    float128 x2 = (this->atoms.allSum - 2);
-    float128 x3 = (this->atoms.allSum - 3);
+    Float x0 = (this->atoms.allSum + 1);
+    Float x1 = (this->atoms.allSum - 1);
+    Float x2 = (this->atoms.allSum - 2);
+    Float x3 = (this->atoms.allSum - 3);
 
-    float128 num = (this->atoms.allSum * x0);
-    float128 denom = (x1 * x2 * x3);
-    float128 fraction = (num / denom);
+    Float num = (this->atoms.allSum * x0);
+    Float denom = (x1 * x2 * x3);
+    Float fraction = (num / denom);
 
     x0 = (atomAllSumPopulation + 1);
     x1 = (atomAllSumPopulation - 1);

--- a/src/acl_results.h
+++ b/src/acl_results.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2013 Mikhail Labushev.
+ *
+ * This file is a part of agemarker-core
+ * library distributed under the MIT License.
+ * For full terms see LICENSE file.
+ */
+
 #ifndef RESULTS_H
 #define RESULTS_H
 

--- a/src/agemarker-core.pro
+++ b/src/agemarker-core.pro
@@ -39,7 +39,7 @@ HEADERS += acl_global.h \
            acl_calculationthread.h \
            acl_results.h \
            acl_atoms.h \
-    acl_float.h
+           acl_float.h
 
 
 LIBS += -lquadmath

--- a/src/agemarker-core.pro
+++ b/src/agemarker-core.pro
@@ -6,7 +6,8 @@
 
 QT       -= gui
 
-QMAKE_CXXFLAGS += -std=gnu++1y
+QMAKE_CXXFLAGS += -std=c++14
+QMAKE_CXXFLAGS += -fext-numeric-literals
 QMAKE_CXXFLAGS_RELEASE += -O2
 
 TARGET = agemarker-core

--- a/src/agemarker-core.pro
+++ b/src/agemarker-core.pro
@@ -4,6 +4,13 @@
 #
 #-------------------------------------------------
 
+# Please note that the library can be compiled to use
+# either "double" precision or quadruple precision
+# (the latter is provided by Boost Multiprecision's
+# "float128" type).
+#
+# See "acl_global.h" file for the preprocessor defines.
+
 QT       -= gui
 
 QMAKE_CXXFLAGS += -std=c++14

--- a/src/agemarker-core.pro
+++ b/src/agemarker-core.pro
@@ -6,7 +6,7 @@
 
 QT       -= gui
 
-QMAKE_CXXFLAGS += -std=gnu++0x
+QMAKE_CXXFLAGS += -std=gnu++1y
 QMAKE_CXXFLAGS_RELEASE += -O2
 
 TARGET = agemarker-core
@@ -30,7 +30,8 @@ HEADERS += acl_global.h \
            acl_data.h \
            acl_calculationthread.h \
            acl_results.h \
-           acl_atoms.h
+           acl_atoms.h \
+    acl_float.h
 
 
 LIBS += -lquadmath

--- a/src/agemarker-core.pro
+++ b/src/agemarker-core.pro
@@ -17,7 +17,11 @@ QMAKE_CXXFLAGS += -std=c++14
 QMAKE_CXXFLAGS += -fext-numeric-literals
 QMAKE_CXXFLAGS_RELEASE += -O2
 
+# When compiling the library with USING_FLOAT128,
+# change TARGET (output filename) to agemarker-core-ep.
+# Don't forget to do the same for the main program.
 TARGET = agemarker-core
+
 TEMPLATE = lib
 
 DEFINES += AGEMARKERCORE_LIBRARY

--- a/src/agemarker-core.pro
+++ b/src/agemarker-core.pro
@@ -6,7 +6,7 @@
 
 QT       -= gui
 
-QMAKE_CXXFLAGS += -std=c++0x
+QMAKE_CXXFLAGS += -std=gnu++0x
 QMAKE_CXXFLAGS_RELEASE += -O2
 
 TARGET = agemarker-core
@@ -31,6 +31,11 @@ HEADERS += acl_global.h \
            acl_calculationthread.h \
            acl_results.h \
            acl_atoms.h
+
+
+LIBS += -lquadmath
+
+INCLUDEPATH += $$quote(c:/Users/mlabu_000.RESONANS-PC/Documents/Libs)
 
 
 unix:!symbian {


### PR DESCRIPTION
Using C++ preprocessor directives, the library can be compiled to use either **"double"** (which can handle up to 12-13 decimal places) or **"boost::multiprecision::float128"** (30-34 decimal places max) as the main type for floating-point numbers.

What's the purpose?

Certain computations require an extended precision (of about 30 decimal places) to get reliable results. For the majority of the calculations, however, a precision of 10-12 decimal digits is quite enough. Since the quadruple-precision (float128) floating points slow down the library by 2-3 times, a decision was made to keep two separate versions of the program: the default one and the "extended precision" one.
